### PR TITLE
Add additional Marketplace dev creds

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -61,22 +61,6 @@
       "whitelisted": true
     },
     {
-      "id": "56fc6da8d185c8e5",
-      "secret": "d1a8f0088e565d066c3d9f28587f5875a800e0a1618a4aaeabd00e162ac583a5",
-      "name": "Fireplace Marketplace Dev",
-      "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
-      "redirectUri": "http://whetstone/fxa-authorize",
-      "whitelisted": true
-    },
-    {
-      "id": "56fc6da8d185c8e7",
-      "secret": "d1a8f0088e565d066c3d9f28587f5875a800e0a1618a4aaeabd00e162ac583a7",
-      "name": "Marketplace Payments Dev",
-      "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
-      "redirectUri": "http://whetstone/mozpay/spa/fxa-auth",
-      "whitelisted": true
-    },
-    {
       "id": "56fc6da8d185c8e4",
       "secret": "d1a8f0088e565d066c3d9f28587f5875a800e0a1618a4aaeabd00e162ac583a4",
       "name": "Fireplace Marketplace Dev",


### PR DESCRIPTION
@washort, @andymckay we want to retire your special snowflake dev FxA integration server and move you over to our better maintained FxA integration server, `stable.dev.lcip.org`, which is a production FxA clone. `marketplace.dev.lcip.org` is bad because it's a weird mix of the production FxA DB and dev Oauth, and it's not being updated regularly.

This PR is an attempt to try to migrate the Oauth creds you have manually created on marketplace.dev.lcip.org. We will not migrate any FxA accounts you have created. 

Is there any reason you need continued SSH access? It would be preferred if you could add further creds via PR to `dannycoates/fxa-dev`. 

In the future, we'll have some better way to manage and provision creds. 

Related bugzilla issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1050602

@washort, @andymckay do the transferred creds look good?
