### PR TITLE
allow the app and ec2-user's to do 'supervisorctl (status|restart|...)'

### DIFF
--- a/roles/common/files/supervisord.conf
+++ b/roles/common/files/supervisord.conf
@@ -8,8 +8,8 @@
 
 [unix_http_server]
 file=/tmp/supervisor.sock   ; (the path to the socket file)
-;chmod=0700                 ; socket file mode (default 0700)
-;chown=nobody:nogroup       ; socket file uid:gid owner
+chmod=0770                  ; socket file mode (default 0700)
+chown=root:supervsr         ; socket file uid:gid owner
 ;username=user              ; (default is no username (open server))
 ;password=123               ; (default is no password (open server))
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,8 +1,16 @@
 ---
 
+- name: create supervsr group for using supervisorctl
+  sudo: true
+  group: name=supervsr state=present
+
 - name: create app user
   sudo: true
-  user: name=app state=present
+  user: name=app state=present append=yes groups=supervsr
+
+- name: add ec2-user to group supervsr
+  sudo: true
+  user: name=ec2-user append=yes groups=supervsr
 
 - name: update installed packages
   sudo: true


### PR DESCRIPTION
After seeing this for the 4th time, it got pretty annoying:

```
app@host $ supervisorctl status
error: <class 'socket.error'>, [Errno 13] Permission denied: file: <string> line: 1
```

So, now app and ec2-user are allowed to get status and manage processes with having to change user.
