### PR TITLE
install mysql-patcher devDependency of fxa-auth-db-server

### DIFF
--- a/roles/authdb/handlers/main.yml
+++ b/roles/authdb/handlers/main.yml
@@ -5,6 +5,11 @@
   sudo_user: app
   npm: path=/data/fxa-auth-db-server production=true
 
+- name: install fxa-auth-db-server mysql-patcher devDependency
+  sudo: true
+  sudo_user: app
+  npm: name=mysql-patcher path=/data/fxa-auth-db-server
+
 - name: run db patcher
   sudo: true
   sudo_user: app

--- a/roles/authdb/tasks/main.yml
+++ b/roles/authdb/tasks/main.yml
@@ -20,6 +20,7 @@
        force=true
   notify:
     - install fxa-auth-db-server dependencies
+    - install fxa-auth-db-server mysql-patcher devDependency
     - run db patcher
     - restart fxa-auth-db-server
 


### PR DESCRIPTION
I don't feel great about pulling in a devDependency when the intent is to install as `--production`, but the alternative is to make mysql-patcher an artificial production dependency. So...
