### PR TITLE
check type before passing to util.table_to_fields

### DIFF
--- a/roles/auth/files/fxa_auth_server.lua
+++ b/roles/auth/files/fxa_auth_server.lua
@@ -55,7 +55,7 @@ function process_message()
         json.agent = nil
     end
 
-    if json.err then
+    if type(json.err) == "table" then
         util.table_to_fields(json.err, json, "err")
         json.err = nil
     end

--- a/roles/authdb/files/fxa_auth_db_server.lua
+++ b/roles/authdb/files/fxa_auth_db_server.lua
@@ -55,7 +55,7 @@ function process_message()
         json.agent = nil
     end
 
-    if json.err then
+    if type(json.err) == "table" then
         util.table_to_fields(json.err, json, "err")
         json.err = nil
     end


### PR DESCRIPTION
This check is from code that is used in production. Without it, heka was crashing like so:

2014/08/29 04:46:20 Decoder 'FxaAuth-FxaAuthDecoder' error: FATAL: process_message() /usr/share/heka/lua_modules/util.lua:15: bad argument #1 to 'pairs' (table expected, got string)
2014/08/29 04:46:20 Shutdown initiated.
