### PR TITLE
mark rds password parameter as NoEcho

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -26,6 +26,7 @@
     },
     "RDSPassword": {
       "Type": "String",
+      "NoEcho": "true",
       "MinLength": "8",
       "Description": "RDS password"
     }


### PR DESCRIPTION
Not that this is a super-secret kind of usage, but might as well not share these by default in the web UI for AWS CloudFormation. 
