### PR TITLE
Remove PhantomJS

### DIFF
--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -25,7 +25,6 @@
   with_items:
     - bower
     - grunt-cli
-    - phantomjs
 
 - name: install fxa-content-server
   tags: code


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-dev/issues/64

@dannycoates we don't need PhantomJS anymore on the content server. Unless something else is using we can remove it.
