### PR TITLE
Add SQS queue for customs ban messages

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -250,6 +250,36 @@
       }
     },
 
+    "FxaCustomsBanQueue": {
+      "Type": "AWS::SQS::Queue"
+    },
+
+    "FxaCustomsBanQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Id": "FxaCustomsBanQueuePolicy",
+          "Statement": [
+            {
+              "Sid": "Allow-Send-To-CustomsBanQueue-From-Anywhere",
+              "Effect": "Allow",
+              "Principal": {"AWS": "*"},
+              "Action":["sqs:SendMessage"],
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow-Read-From-CustomsBanQueue-From-Anywhere",
+              "Effect": "Allow",
+              "Principal": {"AWS": "*"},
+              "Action":["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+              "Resource": "*"
+            }
+          ]
+        },
+        "Queues": [{ "Ref" : "FxaCustomsBanQueue" }]
+      }
+    },
+
     "FxaDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "DependsOn" : [ "FxaEc2Instance", "FxaELB", "FxaRDSInstance" ],
@@ -303,6 +333,10 @@
     "BasketQueueURL": {
       "Description": "Fxa Account Changes for the Basket API consumer",
       "Value": { "Ref": "FxaBasketQueue" }
+    },
+    "CustomsBanQueueURL": {
+      "Description": "Fxa customs ban queue for use by mozdef",
+      "Value": { "Ref": "FxaCustomsBanQueue" }
     },
     "SNS": {
       "Description": "Fxa Account Changes ARN",

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -44,6 +44,7 @@
     rds_host: "{{ hostvars['localhost']['stack']['stack_outputs']['RDSEndpoint'] }}"
     auth_sns_arn: "{{ hostvars['localhost']['stack']['stack_outputs']['SNS'] }}"
     basket_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['BasketQueueURL'] }}"
+    customs_ban_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['CustomsBanQueueURL'] }}"
     authdb_primary_host: "{{ rds_host }}"
     authdb_primary_password: "{{ rds_password }}"
     authdb_replica_host: "{{ rds_host }}"

--- a/roles/customs/defaults/main.yml
+++ b/roles/customs/defaults/main.yml
@@ -3,3 +3,4 @@ customs_private_port: 7000
 customs_memcached_addr_port: 127.0.0.1:11211
 customs_git_repo: https://github.com/mozilla/fxa-customs-server.git
 customs_git_version: master
+customs_ban_queue_url: ""

--- a/roles/customs/templates/config.json.j2
+++ b/roles/customs/templates/config.json.j2
@@ -5,5 +5,9 @@
     "recordLifetimeSeconds": 900,
     "blockIntervalSeconds": 900,
     "maxEmails": 3,
-    "maxBadLogins": 10
+    "maxBadLogins": 10,
+    "bans": {
+      "region": "{{ region }}",
+      "queueUrl": "{{ customs_ban_queue_url }}"
+    }
   }


### PR DESCRIPTION
This adds cloudformation and config for the "customs ban queue", an SQS queue on which the customs server can receive ip/email ban notifications.  It works in my manual testing but we currently have nothing automated to send to this.

The queue has no permissions attached.  I don't really know a good way to add them that would be appropriate for dev/testing while providing sensible security.  Perhaps we can depend on just keeping the endpoint of the queue a secret?

@dannycoates r?
