### PR TITLE
Add a basic sync server to the default setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 node_modules
 aws/my_vars.yml
+*.swp

--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ You can ssh into the EC2 instance with `ssh ec2-user@{{ whatever you configured 
 - content server: https://latest.dev.lcip.org
 - auth server: https://latest.dev.lcip.org/auth/
 - oauth server: https://oauth-latest.dev.lcip.org
+- sync tokenserver: https://latest.dev.lcip.org/syncserver/token/1.0/sync/1.5
 - demo oauth site: https://123done-latest.dev.lcip.org

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -53,6 +53,8 @@
     oauth_db_password: "{{ rds_password }}"
     profile_db_host: "{{ rds_host }}"
     profile_db_password: "{{ rds_password }}"
+    sync_db_host: "{{ rds_host }}"
+    sync_db_password: "{{ rds_password }}"
   vars_files:
     - "environments/{{ stack_name }}.yml"
   roles:
@@ -64,6 +66,7 @@
     - content
     - oauth
     - profile
+    - sync
     - rp
     - log
     - cron_update

--- a/aws/local.yml
+++ b/aws/local.yml
@@ -14,6 +14,8 @@
     oauth_db_password: "{{ rds_password }}"
     profile_db_host: "{{ rds_host }}"
     profile_db_password: "{{ rds_password }}"
+    sync_db_host: "{{ rds_host }}"
+    sync_db_password: "{{ rds_password }}"
   roles:
     - ses
     - memcached
@@ -23,6 +25,7 @@
     - content
     - oauth
     - profile
+    - sync
     - rp
     - log
     - cron_update

--- a/roles/sync/defaults/main.yml
+++ b/roles/sync/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+public_protocol: https
+private_protocol: http
+domain_name: "{{ subdomain }}.{{ hosted_zone }}"
+sync_private_port: 9013
+sync_git_repo: https://github.com/mozilla-services/syncserver.git
+sync_git_version: master
+sync_public_url: "{{ public_protocol }}://{{ domain_name }}/syncserver"
+sync_master_secret: 5382b775a2bdbe0a65ea6cce55f49c4d466bfd7e
+sync_db_host: 127.0.0.1
+sync_db_password:

--- a/roles/sync/files/syncserver.conf
+++ b/roles/sync/files/syncserver.conf
@@ -1,0 +1,13 @@
+[program:syncserver]
+command=/data/syncserver/local/bin/pserve ./syncserver.dev.ini
+directory=/data/syncserver
+autostart=true
+autorestart=unexpected
+startsecs=1
+startretries=3
+stopwaitsecs=3
+stdout_logfile=/var/log/syncserver.log
+stderr_logfile=/var/log/syncserver.err
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=10
+user=app

--- a/roles/sync/handlers/main.yml
+++ b/roles/sync/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: build syncserver virtualenv
+  sudo: true
+  sudo_user: app
+  command: make -C /data/syncserver build
+
+- name: restart syncserver process
+  sudo: true
+  supervisorctl: name=syncserver state=restarted

--- a/roles/sync/meta/main.yml
+++ b/roles/sync/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: common }
+  - { role: web }

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+
+- name: configure nginx upstream
+  sudo: true
+  template: src=upstream.conf.j2 dest=/etc/nginx/conf.d/upstream/http_syncserver.conf
+  notify: reload nginx config
+
+- name: configure nginx location
+  sudo: true
+  template: src=nginx.conf.j2 dest=/etc/nginx/conf.d/location/http_syncserver.conf
+  notify: reload nginx config
+
+- name: install python build environment
+  sudo: true
+  yum: name=python-devel state=present
+
+- name: install mysql command-line tools
+  sudo: true
+  yum: name=mysql
+
+- name: install syncserver build dependencies
+  sudo: true
+  pip: name=virtualenv state=present
+
+- name: create syncserver database
+  sudo: true
+  command: mysql --host={{ sync_db_host }} --user=root --password={{ sync_db_password }} -e "CREATE DATABASE IF NOT EXISTS sync"
+
+- name: install syncserver
+  tags: code
+  sudo: true
+  sudo_user: app
+  git: repo={{ sync_git_repo }}
+       dest=/data/syncserver
+       version={{ sync_git_version }}
+       force=true
+  notify:
+    - build syncserver virtualenv
+    - restart syncserver process
+
+- name: supervise syncserver
+  sudo: true
+  copy: src=syncserver.conf dest=/etc/supervisor.d/syncserver.conf
+  notify: update supervisor
+
+- name: configure syncserver
+  sudo: true
+  sudo_user: app
+  template: src=syncserver.ini.j2 dest=/data/syncserver/syncserver.dev.ini
+  notify: restart syncserver process
+
+- meta: flush_handlers

--- a/roles/sync/templates/nginx.conf.j2
+++ b/roles/sync/templates/nginx.conf.j2
@@ -1,0 +1,9 @@
+location /syncserver/ {
+  proxy_set_header Host $http_host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_redirect off;
+  rewrite ^/syncserver(.*)$ $1 break;
+  proxy_pass http://upstream_sync_server;
+}

--- a/roles/sync/templates/syncserver.ini.j2
+++ b/roles/sync/templates/syncserver.ini.j2
@@ -1,0 +1,35 @@
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = {{ sync_private_port }}
+
+[app:main]
+use = egg:syncserver
+
+[syncserver]
+# This must be edited to point to the public URL of your server,
+# i.e. the URL as seen by Firefox.
+public_url = {{ sync_public_url }}
+
+# This defines the database in which to store all server data.
+sqluri = pymysql://root:{{ sync_db_password }}@{{ sync_db_host }}/sync
+
+# This is a secret key used for signing authentication tokens.
+# It should be long and randomly-generated.
+# The following command will give a suitable value on *nix systems:
+#
+#    head -c 20 /dev/urandom | sha1sum
+#
+# If not specified then the server will generate a temporary one at startup.
+secret = {{ sync_master_secret }}
+
+# Set this to "false" to disable new-user signups on the server.
+# Only request by existing accounts will be honoured.
+# allow_new_users = false
+
+# Uncomment and edit the following to use a local BrowserID verifier
+# rather than posing assertions to the mozilla-hosted verifier.
+# Audiences should be set to your public_url without a trailing slash.
+#[browserid]
+#backend = tokenserver.verifiers.LocalVerifier
+#audiences = https://localhost:5000

--- a/roles/sync/templates/upstream.conf.j2
+++ b/roles/sync/templates/upstream.conf.j2
@@ -1,0 +1,3 @@
+upstream upstream_sync_server {
+    server 127.0.0.1:{{ sync_private_port }};
+}


### PR DESCRIPTION
This adds a basic combined tokenserver+syncstorage setup to use for testing sync.  It should replace the dev servers at https://token.dev.lcip.org/ as we move into the new IAM.

@dannycoates r?
