### PR TITLE
Use X-Forwarded-Proto value provided by the ELB

### DIFF
--- a/roles/sync/templates/nginx.conf.j2
+++ b/roles/sync/templates/nginx.conf.j2
@@ -1,6 +1,6 @@
 location /syncserver/ {
   proxy_set_header Host $http_host;
-  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_redirect off;


### PR DESCRIPTION
The ELB talks to nginx over HTTP, so the previous configuration was telling the app that it's on HTTP and causing confusion.
