### PR TITLE
move auth, content, oauth, profile to train-24

### DIFF
--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -10,11 +10,11 @@ cron_time:
   month: 1
   day: 1
 
-auth_git_version: train-23
-authdb_git_version: train-23
-content_git_version: train-23
-customs_git_version: train-04
+auth_git_version: train-24
+authdb_git_version: train-24
+content_git_version: train-24
+customs_git_version: train-05
 auth_mailer_git_version: cd0c9efc19621d12129f629179427f6ce681716f
-oauth_git_version: 0.23.0
-profile_git_version: 0.23.0
+oauth_git_version: 0.24.0
+profile_git_version: 0.24.0
 rp_git_version: 4651ab27ecf869e8e7985f47bcc103fa866cb617


### PR DESCRIPTION
Production is now on train-24 for auth/content/oauth/profile 

@dannycoates or @ckarlof r? 
