### PR TITLE
New hashed client secret for Chronicle Dev

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -175,7 +175,7 @@
     {
       "id": "1f9bbddcb3e160ab",
       "name": "Chronicle Dev",
-      "hashedSecret": "6701bcc84b928a9507cb0af68f5b0893b0ff7ed6475c3430cfc9f232cc9a14ce",
+      "hashedSecret": "a5becc4855bb302872000dc6ed582a517db20d16b6209d482f70d204bbf97ff7",
       "imageUri": "https://location.services.mozilla.com/static/images/mls-logo@2x.png",
       "redirectUri": "http://localhost:8080/auth/complete",
       "canGrant": false,


### PR DESCRIPTION
Forgot to hash the client secret the first time around. Should be fixed now.
