### PR TITLE
content server - install build requirements only

### DIFF
--- a/roles/content/handlers/main.yml
+++ b/roles/content/handlers/main.yml
@@ -3,7 +3,7 @@
 - name: install fxa-content-server dependencies
   sudo: true
   sudo_user: app
-  command: npm install chdir=/data/fxa-content-server
+  command: npm install --production chdir=/data/fxa-content-server
 
 - name: build fxa-content-server assets
   sudo: true


### PR DESCRIPTION
This speeds up stack deploys 
I deployed this stack with this PR: https://vlad2.dev.lcip.org/signup and double checked to make sure only production dependencies were installed.
