### PR TITLE
reduce auth-server smtp blackout period to zero

### DIFF
--- a/roles/auth/templates/config.json.j2
+++ b/roles/auth/templates/config.json.j2
@@ -22,7 +22,8 @@
         "secure": false,
         "sender":"{{ auth_mail_sender }}",
         "templatePath":"/data/fxa-auth-server/templates/email",
-        "redirectDomain": "firefox.com"
+        "redirectDomain": "firefox.com",
+        "resendBlackoutPeriod": 0
     },
     "listen": {
         "port": {{ auth_private_port }}


### PR DESCRIPTION
In order to test that an email is sent after signing in with an unverified account we need to reduce the blackout period to zero on stage, latest, stable, etc.

Fixes https://github.com/mozilla/fxa-content-server/issues/2033.

@dannycoates r?