### PR TITLE
Switch to fxa-auth-db-mysql for dbserver implementation

### DIFF
--- a/roles/authdb/defaults/main.yml
+++ b/roles/authdb/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 authdb_private_port: 8000
-authdb_git_repo: https://github.com/mozilla/fxa-auth-db-server.git
+authdb_git_repo: https://github.com/mozilla/fxa-auth-db-mysql.git
 authdb_git_version: master
 authdb_primary_host: 127.0.0.1
 authdb_primary_user: root

--- a/roles/authdb/files/fxa-auth-db-server.conf
+++ b/roles/authdb/files/fxa-auth-db-server.conf
@@ -1,5 +1,5 @@
 [program:fxa-auth-db-server]
-command=node /data/fxa-auth-db-server/bin/db_server.js
+command=node /data/fxa-auth-db-mysql/bin/server.js
 autostart=true                ; start at supervisord start (default: true)
 autorestart=unexpected        ; whether/when to restart (default: unexpected)
 startsecs=1                   ; number of secs prog must stay running (def. 1)
@@ -10,7 +10,7 @@ stderr_logfile=/var/log/fxa-auth-db.log        ; stderr log path, NONE for none;
 stderr_logfile_maxbytes=10MB  ; max # logfile bytes b4 rotation (default 50MB)
 stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
 user=app
-directory=/data/fxa-auth-db-server
+directory=/data/fxa-auth-db-mysql
 environment=NODE_ENV="stage"
 
 ;process_name=%(program_name)s ; process_name expr (default %(program_name)s)

--- a/roles/authdb/handlers/main.yml
+++ b/roles/authdb/handlers/main.yml
@@ -1,19 +1,19 @@
 ---
 
-- name: install fxa-auth-db-server dependencies
+- name: install fxa-auth-db-mysql dependencies
   sudo: true
   sudo_user: app
-  npm: path=/data/fxa-auth-db-server production=true
+  npm: path=/data/fxa-auth-db-mysql production=true
 
-- name: install fxa-auth-db-server mysql-patcher devDependency
+- name: install fxa-auth-db-mysql mysql-patcher devDependency
   sudo: true
   sudo_user: app
-  npm: name=mysql-patcher path=/data/fxa-auth-db-server
+  npm: name=mysql-patcher path=/data/fxa-auth-db-mysql
 
 - name: run db patcher
   sudo: true
   sudo_user: app
-  shell: NODE_ENV=stage node bin/db_patcher.js chdir=/data/fxa-auth-db-server
+  shell: NODE_ENV=stage node bin/db_patcher.js chdir=/data/fxa-auth-db-mysql
 
 - name: restart fxa-auth-db-server
   sudo: true

--- a/roles/authdb/tasks/main.yml
+++ b/roles/authdb/tasks/main.yml
@@ -10,24 +10,24 @@
   template: src=heka.toml.j2 dest=/etc/heka.d/fxa-auth-db-server.toml
   notify: restart heka
 
-- name: install fxa-auth-db-server
+- name: install fxa-auth-db-mysql
   tags: code
   sudo: true
   sudo_user: app
   git: repo={{ authdb_git_repo }}
-       dest=/data/fxa-auth-db-server
+       dest=/data/fxa-auth-db-mysql
        version={{ authdb_git_version }}
        force=true
   notify:
-    - install fxa-auth-db-server dependencies
-    - install fxa-auth-db-server mysql-patcher devDependency
+    - install fxa-auth-db-mysql dependencies
+    - install fxa-auth-db-mysql mysql-patcher devDependency
     - run db patcher
     - restart fxa-auth-db-server
 
 - name: configure fxa-auth-db-server
   sudo: true
   sudo_user: app
-  template: src=config.json.j2 dest=/data/fxa-auth-db-server/config/stage.json
+  template: src=config.json.j2 dest=/data/fxa-auth-db-mysql/config/stage.json
   notify: restart fxa-auth-db-server
 
 - name: supervise fxa-auth-db-server


### PR DESCRIPTION
This switches to using the fxa-auth-db-mysql repo for the auth-db-server, which is how things will be after the land the "reverse backends" branch in https://github.com/mozilla/fxa-auth-db-server/issues/60

I renamed the repo and its associated on-disk files to "fxa-auth-db-mysql" but left other things as "fxa-auth-db-server" since that just seems to read nicer.

@chilts @jrgm r?