### PR TITLE
[breakfix] pin nodejs nave usemain to 0.10.36

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: install node
   sudo: true
-  command: /usr/bin/nave usemain stable
+  command: /usr/bin/nave usemain 0.10.36
   # TODO detect actual changes
   changed_when: false
 


### PR DESCRIPTION
Today, nodejs 0.12.0 became available on the nodejs servers, which means that nave stable will now install that version. However, some of our modules won't compile with 0.12.0 at the moment, so pin this back to 0.10.36 until we are ready to move to 0.12.

