### PR TITLE
Set customs_ban_queue_url when updating via cron

### DIFF
--- a/aws/roles/cron_update/defaults/main.yml
+++ b/aws/roles/cron_update/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-fxadev_git_repo: https://github.com/dannycoates/fxa-dev.git
+fxadev_git_repo: https://github.com/mozilla/fxa-dev.git
 fxadev_git_version: master
 cron_time:
   weekday: '*'

--- a/aws/roles/cron_update/tasks/main.yml
+++ b/aws/roles/cron_update/tasks/main.yml
@@ -35,4 +35,4 @@
         day={{ cron_time.day | default('*') }}
         hour={{ cron_time.hour | default('*') }}
         minute={{ cron_time.minute | default('*/10') }}
-        job="cd /data/fxa-dev/aws; ansible-playbook -i localhost, local.yml --extra-vars \"stack_name={{ stack_name }} rds_host={{ rds_host }} auth_sns_arn={{ auth_sns_arn }} basket_queue_url={{ basket_queue_url }}\" > /var/log/ansible/update.log"
+        job="cd /data/fxa-dev/aws; ansible-playbook -i localhost, local.yml --extra-vars \"stack_name={{ stack_name }} rds_host={{ rds_host }} auth_sns_arn={{ auth_sns_arn }} basket_queue_url={{ basket_queue_url }} customs_ban_queue_url={{ customs_ban_queue_url }}\" > /var/log/ansible/update.log"

--- a/roles/customs/defaults/main.yml
+++ b/roles/customs/defaults/main.yml
@@ -3,4 +3,3 @@ customs_private_port: 7000
 customs_memcached_addr_port: 127.0.0.1:11211
 customs_git_repo: https://github.com/mozilla/fxa-customs-server.git
 customs_git_version: master
-customs_ban_queue_url: ""


### PR DESCRIPTION
This setting was getting clobbered on latest, I changed it to match how the basket queue url is handled.  @jrgm r?