### PR TITLE
update {auth,content,oauth,fxa-auth-db} to current productions versions, as of today

### DIFF
--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -10,12 +10,12 @@ cron_time:
   month: 1
   day: 1
 
-auth_git_version: train-29
-authdb_git_version: train-23
-content_git_version: train-29
+auth_git_version: train-30
+authdb_git_version: train-29
+content_git_version: train-30
 customs_git_version: train-05
 auth_mailer_git_version: f90dfa3f2a893fdc8e6ece24858840a67f2732c3
-oauth_git_version: 0.29.0
+oauth_git_version: 0.30.2
 profile_git_version: 0.26.1
 rp_git_version: ac3c556553430afa92d618f399c991603e82a752
 oauth_console_git_version: 0.3.4


### PR DESCRIPTION
update {auth,content,oauth,fxa-auth-db} to current productions versions, as of today. Note: train-29 is correct for fxa-auth-db-server, which is before the reverse db and lock account changes landed.