### PR TITLE
explicitly state canGrant:false where it was missing

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -19,7 +19,8 @@
       "name": "123done",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "{{ rp_public_url }}/api/oauth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "263ceaa5546dce83",
@@ -27,7 +28,8 @@
       "name": "Loop",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "urn:ietf:wg:oauth:2.0:fx:webchannel",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "11c73e2d918ae5d9",
@@ -35,7 +37,8 @@
       "name": "Firefox Marketplace DEV",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "https://marketplace-dev.allizom.org/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "609432f837e54ac2",
@@ -43,7 +46,8 @@
       "name": "Marketplace Payments Dev",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "https://marketplace-dev.allizom.org/mozpay/spa/fxa-auth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "56fc6da8d185c8e3",
@@ -51,7 +55,8 @@
       "name": "Firefox Marketplace Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "59cb05f1f283905a",
@@ -59,7 +64,8 @@
       "name": "Firefox Marketplace Alt DEV",
       "imageUri": "https://oauth-marketplace.dev.lcip.org/img/logo@2x.png",
       "redirectUri": "https://marketplace-altdev.allizom.org/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "85d69c6e30b5e52d",
@@ -67,7 +73,8 @@
       "name": "Firefox Marketplace Payments Alt DEV",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://payments-alt.allizom.org/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "514dadc7fd674e63",
@@ -75,7 +82,8 @@
       "name": "Marketplace Payments Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://payments-alt.allizom.org/mozpay/spa/fxa-auth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "f69290928139452e",
@@ -83,7 +91,8 @@
       "name": "Marketplace Payments Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://mp.dev/mozpay/spa/fxa-auth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "56fc6da8d185c8e4",
@@ -91,7 +100,8 @@
       "name": "Fireplace Marketplace Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://localhost:8080/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "7943afb7b9f54089",
@@ -99,7 +109,8 @@
       "name": "Fireplace Marketplace Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://mp.dev/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "124ae9dff020ba79",
@@ -107,7 +118,8 @@
       "name": "Fireplace Marketplace Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8675/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "31b549f7dfb4de69",
@@ -115,7 +127,8 @@
       "name": "Fireplace Marketplace Comm Dashboard Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8676/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "cc389d4ccd6cd34d",
@@ -123,7 +136,8 @@
       "name": "Fireplace Marketplace Stats Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8677/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "47354b86fb361c7e",
@@ -131,7 +145,8 @@
       "name": "Fireplace Marketplace Editorial Tools Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8678/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "049d4b105daa1cb9",
@@ -139,7 +154,8 @@
       "name": "Fireplace Marketplace Operator Dashboard Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8679/fxa-authorize",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
 
     {
@@ -148,7 +164,8 @@
       "name": "FMD Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8000/oauth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "0fddc2b28f47c2d7",
@@ -156,7 +173,8 @@
       "name": "Find My Device Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://find.dev.mozaws.net/oauth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "name": "FxA OAuth Console DEV",
@@ -228,7 +246,8 @@
       "hashedSecret": "97285a0eec1a29bc9f14267251d32fbcaf56dd7f0fb5f1121bcede6b4f11a8ab",
       "imageUri": "",
       "redirectUri": "https://support.mozilla.org/redirects/buddyup-fxa-oauth",
-      "whitelisted": true
+      "whitelisted": true,
+      "canGrant": false
     },
     {
       "id": "66041b7ec3991ec0",


### PR DESCRIPTION
This is a companion fix to https://github.com/mozilla/fxa-oauth-server/pull/218 where having these keys is now required.