### PR TITLE
remove oauth dependency to clear up issue with fxa-oauth-console getting clobbered

### DIFF
--- a/roles/able/meta/main.yml
+++ b/roles/able/meta/main.yml
@@ -2,4 +2,4 @@
 dependencies:
   - { role: common }
   - { role: web }
-  - { role: oauth }
+


### PR DESCRIPTION
This "fixes" https://github.com/mozilla/fxa-dev/issues/102 so changes to `able` don't trigger `oauth` from overwriting changes done by `oauth-console`. The right fix is to use nginx includes, but on the other hand, I'm not sure why `able` is declaring a dependency on `oauth` that the other roles do not declare. I'll look into fixing the nginx config, but this should get the oauth console working for actual use. 