### PR TITLE
Add credentials for Firefox Browser Compatibility API

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -266,6 +266,15 @@
       "redirectUri": "",
       "whitelisted": true,
       "canGrant": true
+    },
+    {
+      "id": "33c663065dee0b86",
+      "name": "Firefox Browser Compatibility API",
+      "hashedSecret": "ef9b091498b2b1ba01ab4e06993b10393cb059a06a8f33941334ab83f84872f5",
+      "imageUri": "",
+      "redirectUri": "https://browsercompat.herokuapp.com/accounts/fxa/login/callback/",
+      "whitelisted": true,
+      "canGrant": false
     }
   ],
   "env": "stage",


### PR DESCRIPTION
See https://github.com/mozilla/fxa-oauth-server/issues/224

@seanmonstar is this still the canonical way to add long-lived dev credentials?