### PR TITLE
Oauth internal server and works with oauth-console

### DIFF
--- a/roles/oauth-console/tasks/main.yml
+++ b/roles/oauth-console/tasks/main.yml
@@ -1,8 +1,19 @@
 ---
 
-- name: configure nginx
+- file: path=/etc/nginx/conf.d/oauth_console/upstream state=directory
   sudo: true
-  template: src=upstream.conf.j2 dest=/etc/nginx/conf.d/upstream/http_fxa_oauth.conf
+
+- name: configure nginx upstream
+  sudo: true
+  template: src=upstream.conf.j2 dest=/etc/nginx/conf.d/oauth_console/upstream/http_fxa_oauth_console.conf
+  notify: reload nginx config
+
+- file: path=/etc/nginx/conf.d/oauth_console/location state=directory
+  sudo: true
+
+- name: configure nginx location
+  sudo: true
+  template: src=location.conf.j2 dest=/etc/nginx/conf.d/oauth_console/location/http_fxa_oauth_console.conf
   notify: reload nginx config
 
 - name: install fxa-oauth-console

--- a/roles/oauth-console/templates/location.conf.j2
+++ b/roles/oauth-console/templates/location.conf.j2
@@ -1,7 +1,7 @@
-location /v1/client {
+location /console/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header Host $http_host;
   proxy_redirect off;
-  rewrite ^(.*)$ $1 break;
-  proxy_pass http://upstream_oauth_internal_server;
+  rewrite ^/console(.*)$ $1 break;
+  proxy_pass http://upstream_oauth_console_server;
 }

--- a/roles/oauth-console/templates/upstream.conf.j2
+++ b/roles/oauth-console/templates/upstream.conf.j2
@@ -1,28 +1,3 @@
-upstream upstream_oauth_server {
-    server 127.0.0.1:{{ oauth_private_port }};
-}
-
 upstream upstream_oauth_console_server {
     server 127.0.0.1:{{ oauth_console_private_port }};
-}
-
-server {
-  listen 1443;
-  server_name {{ oauth_domain_name }};
-
-  location / {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_redirect off;
-    proxy_pass http://upstream_oauth_server;
-  }
-
-  location /console/ {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_redirect off;
-    rewrite ^/console(.*)$ $1 break;
-    proxy_pass http://upstream_oauth_console_server;
-  }
-
 }

--- a/roles/oauth/defaults/main.yml
+++ b/roles/oauth/defaults/main.yml
@@ -3,6 +3,7 @@ public_protocol: https
 private_protocol: http
 domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 oauth_private_port: 9010
+oauth_internal_port: 9011
 oauth_db_host: 127.0.0.1
 oauth_db_password:
 oauth_domain_name: "oauth-{{ domain_name }}"

--- a/roles/oauth/defaults/main.yml
+++ b/roles/oauth/defaults/main.yml
@@ -3,7 +3,7 @@ public_protocol: https
 private_protocol: http
 domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 oauth_private_port: 9010
-oauth_internal_port: 9111
+oauth_internal_private_port: 9111
 oauth_db_host: 127.0.0.1
 oauth_db_password:
 oauth_domain_name: "oauth-{{ domain_name }}"

--- a/roles/oauth/defaults/main.yml
+++ b/roles/oauth/defaults/main.yml
@@ -3,7 +3,7 @@ public_protocol: https
 private_protocol: http
 domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 oauth_private_port: 9010
-oauth_internal_port: 9011
+oauth_internal_port: 9111
 oauth_db_host: 127.0.0.1
 oauth_db_password:
 oauth_domain_name: "oauth-{{ domain_name }}"

--- a/roles/oauth/files/fxa-oauth-server.conf
+++ b/roles/oauth/files/fxa-oauth-server.conf
@@ -1,4 +1,7 @@
-[program:fxa-oauth-server]
+[group:fxa-oauth]
+programs=oauth-server,oauth-internal
+
+[program:oauth-server]
 command=node /data/fxa-oauth-server/bin/server.js
 autostart=true
 autorestart=unexpected
@@ -7,6 +10,20 @@ startretries=3
 stopwaitsecs=3
 stdout_logfile=/var/log/fxa-oauth.log
 stderr_logfile=/var/log/fxa-oauth.err
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=10
+environment=CONFIG_FILES="/data/fxa-oauth-server/config/awsbox.json,/data/fxa-oauth-server/config/local.json"
+user=app
+
+[program:oauth-internal]
+command=node /data/fxa-oauth-server/bin/internal.js
+autostart=true
+autorestart=unexpected
+startsecs=1
+startretries=3
+stopwaitsecs=3
+stdout_logfile=/var/log/fxa-oauth-internal.log
+stderr_logfile=/var/log/fxa-oauth-internal.err
 stderr_logfile_maxbytes=10MB
 stderr_logfile_backups=10
 environment=CONFIG_FILES="/data/fxa-oauth-server/config/awsbox.json,/data/fxa-oauth-server/config/local.json"

--- a/roles/oauth/handlers/main.yml
+++ b/roles/oauth/handlers/main.yml
@@ -5,6 +5,7 @@
   sudo_user: app
   npm: path=/data/fxa-oauth-server production=true
 
-- name: restart fxa-oauth-server
+- name: restart fxa-oauth:* group
   sudo: true
-  supervisorctl: name=fxa-oauth-server state=restarted
+  # restarts group if name ends with ':'; must be quoted
+  supervisorctl: name="fxa-oauth:" state=restarted

--- a/roles/oauth/tasks/main.yml
+++ b/roles/oauth/tasks/main.yml
@@ -15,13 +15,13 @@
        force=true
   notify:
     - install fxa-oauth-server dependencies
-    - restart fxa-oauth-server
+    - restart fxa-oauth:* group
 
 - name: configure fxa-oauth-server
   sudo: true
   sudo_user: app
   template: src=config.json.j2 dest=/data/fxa-oauth-server/config/local.json
-  notify: restart fxa-oauth-server
+  notify: restart fxa-oauth:* group
 
 - name: supervise fxa-oauth-server
   sudo: true

--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -284,7 +284,7 @@
       "id": "2e59bc0f30faa234",
       "hashedSecret": "340e85670318d659ffa94507a75b464ca6e0d55aeb6d9da0e1eb6c4695b3c3a7",
       "whitelisted": true
-    },    
+    },
     {
       "id": "66041b7ec3991ec0",
       "name": "FxaOauthClient",
@@ -305,6 +305,10 @@
     }
   ],
   "env": "stage",
+  "internal": {
+    "host": "127.0.0.1",
+    "port": {{ oauth_internal_port }}
+  },
   "logging": {
     "formatters": {
       "pretty": {

--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -307,7 +307,7 @@
   "env": "stage",
   "serverInternal": {
     "host": "127.0.0.1",
-    "port": {{ oauth_internal_port }}
+    "port": {{ oauth_internal_private_port }}
   },
   "logging": {
     "formatters": {

--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -305,7 +305,7 @@
     }
   ],
   "env": "stage",
-  "internal": {
+  "serverInternal": {
     "host": "127.0.0.1",
     "port": {{ oauth_internal_port }}
   },

--- a/roles/oauth/templates/nginx.conf.j2
+++ b/roles/oauth/templates/nginx.conf.j2
@@ -1,0 +1,7 @@
+location /v1/client {
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header Host $http_host;
+  proxy_redirect off;
+  rewrite ^(.*)$ $1 break;
+  proxy_pass http://upstream_oauth_internal_server;
+}

--- a/roles/oauth/templates/upstream.conf.j2
+++ b/roles/oauth/templates/upstream.conf.j2
@@ -46,7 +46,13 @@ server {
     proxy_set_header Host $http_host;
     proxy_redirect off;
     rewrite ^(.*)$ $1 break;
+
+    # Switch backend server based on method. Set internal as default.
     proxy_pass http://upstream_oauth_internal_server;
+
+    # For requests that are not PUT, POST, or DELETE, use the
+    # upstream_oauth_server. This means GET /v1/client/{client_id}
+    # will be handled by the main oauth server.
     limit_except PUT POST DELETE {
       proxy_pass http://upstream_oauth_server;
     }

--- a/roles/oauth/templates/upstream.conf.j2
+++ b/roles/oauth/templates/upstream.conf.j2
@@ -2,6 +2,13 @@ upstream upstream_oauth_server {
     server 127.0.0.1:{{ oauth_private_port }};
 }
 
+upstream upstream_oauth_internal_server {
+    server 127.0.0.1:{{ oauth_internal_port }};
+}
+
+# pull in upstream_oauth_console_server
+include /etc/nginx/conf.d/oauth_console/upstream/*.conf;
+
 server {
   listen 1443;
   server_name {{ oauth_domain_name }};
@@ -12,4 +19,39 @@ server {
     proxy_redirect off;
     proxy_pass http://upstream_oauth_server;
   }
+
+  #
+  # Internal server implements these routes:
+  #
+  # GET /v1/clients
+  # POST /v1/client
+  # POST /v1/client/{client_id}
+  # DELETE /v1/client/{client_id}
+  #
+  # However, `GET /client` must be routed to the regular
+  # oauth server. So, exactly match `GET /v1/clients` and
+  # condition the proxy_pass on the `/v1/client` method.
+  #
+
+  location = /v1/clients {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    rewrite ^(.*)$ $1 break;
+    proxy_pass http://upstream_oauth_internal_server;
+  }
+
+  location /v1/client {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    rewrite ^(.*)$ $1 break;
+    proxy_pass http://upstream_oauth_internal_server;
+    limit_except PUT POST DELETE {
+      proxy_pass http://upstream_oauth_server;
+    }
+  }
+
+  # pull in location /console
+  include /etc/nginx/conf.d/oauth_console/location/*.conf;
 }

--- a/roles/oauth/templates/upstream.conf.j2
+++ b/roles/oauth/templates/upstream.conf.j2
@@ -3,7 +3,7 @@ upstream upstream_oauth_server {
 }
 
 upstream upstream_oauth_internal_server {
-    server 127.0.0.1:{{ oauth_internal_port }};
+    server 127.0.0.1:{{ oauth_internal_private_port }};
 }
 
 # pull in upstream_oauth_console_server


### PR DESCRIPTION
This builds on @seanmonstar's work on oauth.

- fixes a port conflict with profile server
- finally separates the fight over nginx config files between oauth and oauth-console
- sets up rules to support the oauth-console with the new oauth-internal server

```
  Internal server implements these routes:
  
  GET /v1/clients
  POST /v1/client
  POST /v1/client/{client_id}
  DELETE /v1/client/{client_id}
  
  However, `GET /client` must be routed to the regular
  oauth server. So, exactly match `GET /v1/clients` and
  condition the proxy_pass on the `/v1/client` method.
```
This passes all the selenium functional tests and the console works correctly.

@dannycoates, @seanmonstar, @vladikoff - look ok?