### PR TITLE
fix(able): change the supervisord startup command to bin/server.js

### DIFF
--- a/roles/able/files/able.conf
+++ b/roles/able/files/able.conf
@@ -1,5 +1,5 @@
 [program:able]
-command=node index.js
+command=node bin/server.js
 directory=/data/able
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
Hi @dannycoates. Noticed that able was not starting on fxa-dev boxes. 