### PR TITLE
added fxa-notification-server

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -130,7 +130,8 @@
                     "arn:aws:s3:::net.mozaws.ops.hiera-secrets/app/fxa.dev.yaml"
                   ]
                },
-               { "Effect":"Allow", "Action": [ "ec2:DescribeTags" ], "Resource": "*" }
+               { "Effect":"Allow", "Action": [ "ec2:DescribeTags" ], "Resource": "*" },
+               { "Effect":"Allow", "Action": [ "elasticache:DescribeCacheClusters" ], "Resource": "*" }
              ]
             }
           }
@@ -310,6 +311,29 @@
       }
     },
 
+    "RedisClusterSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Fxa Notifications Elasticache Group",
+        "SecurityGroupIngress": [ {
+          "IpProtocol": "tcp",
+          "FromPort": "6379",
+          "ToPort": "6379",
+          "SourceSecurityGroupName": {"Ref": "FxaDevSecurityGroup"}
+        } ]
+      }
+    },
+
+    "FxaNotificationsRedisCluster": {
+      "Type": "AWS::ElastiCache::CacheCluster",
+      "Properties": {
+        "CacheNodeType": "cache.t2.micro",
+        "Engine": "redis",
+        "NumCacheNodes": "1",
+        "VpcSecurityGroupIds": [{"Fn::GetAtt": ["RedisClusterSecurityGroup", "GroupId"]}]
+      }
+    },
+
     "FxaDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "DependsOn" : [ "FxaEc2Instance", "FxaELB", "FxaRDSInstance" ],
@@ -371,6 +395,10 @@
     "SNS": {
       "Description": "Fxa Account Changes ARN",
       "Value": { "Ref": "FxaSNSTopic" }
+    },
+    "Redis": {
+      "Description": "Fxa Notifications Redis",
+      "Value": { "Ref": "FxaNotificationsRedisCluster" }
     }
   }
 }

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -45,6 +45,7 @@
     auth_sns_arn: "{{ hostvars['localhost']['stack']['stack_outputs']['SNS'] }}"
     basket_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['BasketQueueURL'] }}"
     customs_ban_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['CustomsBanQueueURL'] }}"
+    redis_id: "{{ hostvars['localhost']['stack']['stack_outputs']['Redis'] }}"
     authdb_primary_host: "{{ rds_host }}"
     authdb_primary_password: "{{ rds_password }}"
     authdb_replica_host: "{{ rds_host }}"
@@ -66,6 +67,7 @@
     - content
     - oauth
     - oauth-console
+    - notifications
     - profile
     - kv
     - sync

--- a/aws/environments/dcoates.yml
+++ b/aws/environments/dcoates.yml
@@ -9,6 +9,7 @@ auth_git_version: ab-test
 rp_git_repo: https://github.com/dannycoates/123done.git
 content_git_repo: https://github.com/dannycoates/fxa-content-server.git
 content_git_version: ablify
+notification_git_version: redis
 cron_time:
   minute: 0
   hour: 0

--- a/aws/local.yml
+++ b/aws/local.yml
@@ -25,6 +25,7 @@
     - content
     - oauth
     - oauth-console
+    - notifications
     - profile
     - sync
     - rp

--- a/aws/roles/ses/tasks/main.yml
+++ b/aws/roles/ses/tasks/main.yml
@@ -14,6 +14,7 @@
       object=/app/fxa.dev.yaml
       dest=/data/fxa.dev.yml
       mode=get
+  changed_when: false
 
 - shell: 'grep -e "fxa::smtp::user" /data/fxa.dev.yml | sed "s/^fxa::smtp::user: ''\([^'']\+\)''/\1/"'
   sudo: true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: install node
   sudo: true
-  command: /usr/bin/nave usemain 0.10.36
+  command: /usr/bin/nave usemain 0.10
   # TODO detect actual changes
   changed_when: false
 

--- a/roles/notifications/defaults/main.yml
+++ b/roles/notifications/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+public_protocol: https
+domain_name: "{{ subdomain }}.{{ hosted_zone }}"
+notification_public_port: 7879
+oauth_public_host: "oauth-{{ domain_name }}"
+oauth_public_port: 443
+auth_public_url: "{{ public_protocol }}://{{ domain_name }}"
+redis_port: 6379
+notification_git_repo: https://github.com/mozilla/fxa-notification-server.git
+notification_git_version: master

--- a/roles/notifications/files/fxa-notification-server.conf
+++ b/roles/notifications/files/fxa-notification-server.conf
@@ -1,0 +1,14 @@
+[program:fxa-notification-server]
+command=node server.js
+directory=/data/fxa-notification-server
+autostart=true
+autorestart=unexpected
+startsecs=1
+startretries=3
+stopwaitsecs=3
+stdout_logfile=NONE
+stderr_logfile=/var/log/fxa-notification.log
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=10
+user=app
+environment=NODE_ENV="stage"

--- a/roles/notifications/files/generate_keys.sh
+++ b/roles/notifications/files/generate_keys.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+openssl genrsa -out /data/fxa-notification-server/secret.pem 2048
+openssl rsa -in /data/fxa-notification-server/secret.pem -pubout -out /data/fxa-notification-server/public.pem

--- a/roles/notifications/handlers/main.yml
+++ b/roles/notifications/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: install fxa-notification-server dependencies
+  sudo: true
+  sudo_user: app
+  npm: path=/data/fxa-notification-server
+
+- name: restart fxa-notification-server
+  sudo: true
+  supervisorctl: name=fxa-notification-server state=restarted

--- a/roles/notifications/meta/main.yml
+++ b/roles/notifications/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: common }

--- a/roles/notifications/tasks/main.yml
+++ b/roles/notifications/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+
+- name: install fxa-notification-server
+  tags: code
+  sudo: true
+  sudo_user: app
+  git: repo={{ notification_git_repo }}
+       dest=/data/fxa-notification-server
+       version={{ notification_git_version }}
+       force=true
+  notify: #so meta
+    - install fxa-notification-server dependencies
+    - restart fxa-notification-server
+
+- name: install json tool
+  sudo: true
+  npm: name=json global=yes
+
+- name: find redis
+  shell: 'aws elasticache describe-cache-clusters --cache-cluster-id {{ redis_id }} --region {{ region }} --show-cache-node-info | json CacheClusters[0].CacheNodes[0].Endpoint.Address'
+  changed_when: false
+  register: redis_host
+
+- name: configure fxa-notification-server
+  sudo: true
+  sudo_user: app
+  template: src=config.json.j2 dest=/data/fxa-notification-server/config.json
+  notify: restart fxa-notification-server
+
+- name: create keys
+  sudo: true
+  sudo_user: app
+  script: generate_keys.sh creates=/data/fxa-notification-server/secret.pem
+
+- name: supervise fxa-notification-server
+  sudo: true
+  copy: src=fxa-notification-server.conf dest=/etc/supervisor.d/fxa-notification-server.conf
+  notify: update supervisor
+
+- meta: flush_handlers

--- a/roles/notifications/templates/config.json.j2
+++ b/roles/notifications/templates/config.json.j2
@@ -1,0 +1,21 @@
+{
+  "server": {
+    "port": {{ notification_public_port }}
+  },
+  "oauth": {
+    "host": "{{ oauth_public_host }}",
+    "port": {{ oauth_public_port }}
+  },
+  "jwk": {
+    "secretKeyFile": "./secret.pem",
+    "publicKeyFile": "./public.pem",
+    "trustedJKUs": ["{{ auth_public_url }}/.well-known/public-keys"]
+  },
+  "db": {
+    "driver": "redis",
+    "redis": {
+      "host": "{{ redis_host.stdout }}",
+      "port": {{ redis_port }}
+    }
+  }
+}


### PR DESCRIPTION
This adds a new redis elasticache instance and the fxa-notification-server. This config depends on the redis PR of the server, not yet in master https://github.com/mozilla/fxa-notification-server/pull/19

