### PR TITLE
fix(auth): not sure why, but a value for auth_public_url needs to be set now

### DIFF
--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -4,3 +4,4 @@ subdomain: latest.dev
 hosted_zone: lcip.org
 ssl_certificate_name: exp20170412_wildcard_dev_lcip.org
 rds_password: 33yJ(Lv)hr6&=N7t
+auth_public_url: https://latest.dev.lcip.org/auth


### PR DESCRIPTION
So, the config value for publicUrl started being set to https://latest.dev.lcip.org/ (no /auth) sometime today. Almost certainly something in the notifications changes triggered that but don't quite understand it. 

But for now, setting this explicity in latest.yml, gets the auth server config back to where it was. 