### PR TITLE
add internal port config for the oauth console

### DIFF
--- a/roles/oauth-console/templates/config.json.j2
+++ b/roles/oauth-console/templates/config.json.j2
@@ -4,6 +4,7 @@
     "client_secret": "2be80db1d3cf5ddef69d5e23d7d1885e3bbc09f53781d44a8e2f3507a8d6a62c",
     "redirect_uri": "{{ oauth_public_url }}/console/oauth/redirect",
     "oauth_uri": "{{ oauth_public_url }}/v1",
+    "oauth_internal_uri": "{{ oauth_public_url }}/v1",
     "profile_uri": "{{ profile_public_url }}/v1"
   },
   "base_url": "/console/",


### PR DESCRIPTION
Requires mozilla/fxa-oauth-server#235
Requires https://github.com/mozilla/fxa-oauth-console/pull/28

Waiting for those PRs first...