### PR TITLE
update auth and content to train-34, and update ELB Policy to right one

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -173,7 +173,7 @@
           {
             "InstancePort":"1443",
             "LoadBalancerPort":"443",
-            "PolicyNames" : ["ELBSecurityPolicy-2015-02"],
+            "PolicyNames" : ["ELBSecurityPolicy-2015-03"],
             "Protocol":"HTTPS",
             "SSLCertificateId":{
                "Fn::Join":[ "",

--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -10,10 +10,10 @@ cron_time:
   month: 1
   day: 1
 
-auth_git_version: train-33
-authdb_git_version: train-33
-content_git_version: train-33
-customs_git_version: train-33
+auth_git_version: train-34
+authdb_git_version: train-34
+content_git_version: train-34
+customs_git_version: train-34
 auth_mailer_git_version: 31470ec0361a773688d2a295f7f5a39686909ed1
 oauth_git_version: 0.33.0
 profile_git_version: 0.33.0


### PR DESCRIPTION
Same old. Not asking for review. 

The ELB Policy update is needed since ELBSecurityPolicy-2015-02 has been removed.