### PR TITLE
fix(oauth-console): use low-pri, not exact, match on path /v1/developer

### DIFF
--- a/roles/oauth/templates/upstream.conf.j2
+++ b/roles/oauth/templates/upstream.conf.j2
@@ -42,14 +42,6 @@ server {
     proxy_pass http://upstream_oauth_internal_server;
   }
 
-  location = /v1/developer {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_redirect off;
-    rewrite ^(.*)$ $1 break;
-    proxy_pass http://upstream_oauth_internal_server;
-  }
-
   location /v1/client {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
@@ -65,6 +57,14 @@ server {
     limit_except PUT POST DELETE {
       proxy_pass http://upstream_oauth_server;
     }
+  }
+
+  location /v1/developer {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    rewrite ^(.*)$ $1 break;
+    proxy_pass http://upstream_oauth_internal_server;
   }
 
   # pull in location /console


### PR DESCRIPTION
Sorry, saw this when it came in and then forgot to come back to it. 

So, `location = /v1/developer` will match exactly `/v1/developer` and nothing else, i.e., it won't match `/v1/developer/activate`. So use a looser match for anything on that path prefix.