### PR TITLE
fix(ssh): use a shorter ssh control_path setting

### DIFF
--- a/aws/ansible.cfg
+++ b/aws/ansible.cfg
@@ -158,7 +158,7 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=
 # may wish to shorten the string below.
 #
 # Example:
-# control_path = %(directory)s/%%h-%%r
+control_path = %(directory)s/%%h%%p%%r
 #control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
 
 # Enabling pipelining reduces the number of SSH operations required to


### PR DESCRIPTION
I used to have this fixed with a Host pattern in my `.ssh/config`, but switched computers and hit this limit on the length of the socket filename (104 on osx, 108 on linux). Anyways, since the control sockets are going to be put in a (hard-coded) directory of `$HOME/.ansible/cp`, beginning each socket filename with `ansible-ssh-` adds no new information really. So dropping that allows the socket name to be short enough by just a few characters.

r? @vladikoff, @dannycoates 