### PR TITLE
fix(fxa-content): configuration and daemons to support email opt-in

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -173,7 +173,7 @@
           {
             "InstancePort":"1443",
             "LoadBalancerPort":"443",
-            "PolicyNames" : ["ELBSecurityPolicy-2015-03"],
+            "PolicyNames" : ["ELBSecurityPolicy-2015-05"],
             "Protocol":"HTTPS",
             "SSLCertificateId":{
                "Fn::Join":[ "",

--- a/roles/content/defaults/main.yml
+++ b/roles/content/defaults/main.yml
@@ -11,3 +11,4 @@ content_public_port: 80
 content_private_port: 3030
 content_git_repo: https://github.com/mozilla/fxa-content-server.git
 content_git_version: master
+basket_private_port: 1114

--- a/roles/content/files/fxa-basket-proxy.conf
+++ b/roles/content/files/fxa-basket-proxy.conf
@@ -1,0 +1,15 @@
+[program:fxa-basket-proxy]
+command=node /data/fxa-content-server/server/bin/basket-proxy-server.js
+autostart=true
+autorestart=unexpected
+startsecs=1
+startretries=3
+stopwaitsecs=3
+stdout_logfile=/var/log/fxa-basket-proxy.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stderr_logfile=/var/log/fxa-basket-proxy.err
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=10
+environment=CONFIG_FILES="/data/fxa-content-server/server/config/awsbox.json,/data/fxa-content-server/server/config/local.json"
+user=app

--- a/roles/content/files/fxa-null-basket.conf
+++ b/roles/content/files/fxa-null-basket.conf
@@ -1,0 +1,15 @@
+[program:fxa-null-basket]
+command=node /data/fxa-content-server/server/bin/null-basket-server.js
+autostart=true
+autorestart=unexpected
+startsecs=1
+startretries=3
+stopwaitsecs=3
+stdout_logfile=/var/log/fxa-null-basket.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stderr_logfile=/var/log/fxa-null-basket.err
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=10
+environment=CONFIG_FILES="/data/fxa-content-server/server/config/awsbox.json,/data/fxa-content-server/server/config/local.json"
+user=app

--- a/roles/content/handlers/main.yml
+++ b/roles/content/handlers/main.yml
@@ -13,3 +13,11 @@
 - name: restart fxa-content-server
   sudo: true
   supervisorctl: name=fxa-content-server state=restarted
+
+- name: restart fxa-basket-proxy
+  sudo: true
+  supervisorctl: name=fxa-basket-proxy state=restarted
+
+- name: restart fxa-null-basket
+  sudo: true
+  supervisorctl: name=fxa-null-basket state=restarted

--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -43,11 +43,24 @@
   sudo: true
   sudo_user: app
   template: src=config.json.j2 dest=/data/fxa-content-server/server/config/local.json
-  notify: restart fxa-content-server
+  notify:
+    - restart fxa-content-server
+    - restart fxa-basket-proxy
+    - restart fxa-null-basket
 
 - name: supervise fxa-content-server
   sudo: true
   copy: src=fxa-content-server.conf dest=/etc/supervisor.d/fxa-content-server.conf
+  notify: update supervisor
+
+- name: supervise fxa-basket-proxy
+  sudo: true
+  copy: src=fxa-basket-proxy.conf dest=/etc/supervisor.d/fxa-basket-proxy.conf
+  notify: update supervisor
+
+- name: supervise fxa-null-basket
+  sudo: true
+  copy: src=fxa-null-basket.conf dest=/etc/supervisor.d/fxa-null-basket.conf
   notify: update supervisor
 
 - meta: flush_handlers

--- a/roles/content/templates/config.json.j2
+++ b/roles/content/templates/config.json.j2
@@ -15,5 +15,14 @@
   "page_template_subdirectory": "dist",
   "metrics" : {
     "sample_rate" : 1
+  },
+  "basket": {
+    "proxy_url": "http://127.0.0.1:{{ basket_private_port }}",
+    "api_url": "http://127.0.0.1:10140",
+    "api_key": "good enough for use with localhost null server"
+  },
+  "marketing_email": {
+    "api_url": "{{ content_public_url }}/basket",
+    "preferences_url": "https://www-dev.allizom.org/newsletter/existing/"
   }
 }

--- a/roles/content/templates/nginx.conf.j2
+++ b/roles/content/templates/nginx.conf.j2
@@ -4,3 +4,11 @@ location / {
     proxy_redirect off;
     proxy_pass http://upstream_content_server;
 }
+
+location /basket {
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header Host $http_host;
+  proxy_redirect off;
+  rewrite ^/basket(.*)$ $1 break;
+  proxy_pass http://upstream_basket_server;
+}

--- a/roles/content/templates/upstream.conf.j2
+++ b/roles/content/templates/upstream.conf.j2
@@ -1,3 +1,7 @@
 upstream upstream_content_server {
     server 127.0.0.1:{{ content_private_port }};
 }
+
+upstream upstream_basket_server {
+    server 127.0.0.1:{{ basket_private_port }};
+}


### PR DESCRIPTION
[DO NOT MERGE YET] - this depends on branches of fxa-content-server to merge to master; without that code landed these changes will have problems since they will try to start programs that dont' exist on master yet. 

Anyways, this change will run the basket proxy server along with the "null server" a simple implementation of the Basket api. You can edit fxa-content-server/server/config/local.json to change api_url and api_token to point at a Basket staging or production server if you wish. 

Note on this change:
fix(elb,tls): update to ELBSecurityPolicy-2015-05 (N.B., may not be compatible with older clients)

We may need to set a custom policy to accomodate Android 2.3, but as of today the 2015-03 is no longer available. So it's either 2015-05 with no DHE, or cannot build a new stack, at the moment.

r? @zaach, @vlad?

