### PR TITLE
fix(config): remove unused config "ab_url"

### DIFF
--- a/roles/content/templates/config.json.j2
+++ b/roles/content/templates/config.json.j2
@@ -3,7 +3,6 @@
   "public_url": "{{ content_public_url }}",
   "oauth_url": "{{ oauth_public_url }}",
   "profile_url": "{{ profile_public_url }}",
-  "ab_url": "{{ content_public_url }}/ab/v1/fxa_content_server/experiments.bundle.js",
   "env": "production",
   "use_https": false,
   "static_max_age" : 0,


### PR DESCRIPTION
This is unused in current content-server, and causes strict convict mode to throw (not defined in content-server's config schema server/lib/configuration). 

r? @dannycoates 