### PR TITLE
chore(stable): bump versions to train-39 and related

### DIFF
--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -10,12 +10,12 @@ cron_time:
   month: 1
   day: 1
 
-auth_git_version: train-38
-authdb_git_version: train-37
-content_git_version: train-38
-customs_git_version: train-36
-auth_mailer_git_version: d2eb3b298464455c8fe18fd964141ba89a0d1a0e
-oauth_git_version: 0.36.1
-profile_git_version: 0.36.0
+auth_git_version: v1.39.1
+authdb_git_version: v0.39.0
+content_git_version: v0.39.0
+customs_git_version: v0.39.0
+auth_mailer_git_version: 04c789673c8a55139515ab1a24ee5f06cc3bf8ce
+oauth_git_version: 0.39.0
+profile_git_version: 0.39.0
 rp_git_version: 72e99f2e71bb7f39e2102446a68f1595f1514b6d
 oauth_console_git_version: 0.3.8


### PR DESCRIPTION
Just standard bump of versions to train-39, although I'm using the actual tag name instead of head of the train branch (and yes, some tags are 'vM.N.O' and others are 'M.N.O', no 'v'). 