### PR TITLE
chore(oauth): remove the deprecated "whitelisted" column from oauth clients

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -19,7 +19,6 @@
       "name": "123done",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "{{ rp_public_url }}/api/oauth",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -38,7 +37,6 @@
       "name": "Loop",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "urn:ietf:wg:oauth:2.0:fx:webchannel",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -48,7 +46,6 @@
       "name": "Firefox Marketplace DEV",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "https://marketplace-dev.allizom.org/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -58,7 +55,6 @@
       "name": "Marketplace Payments Dev",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "https://marketplace-dev.allizom.org/mozpay/spa/fxa-auth",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -68,7 +64,6 @@
       "name": "Firefox Marketplace Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -78,7 +73,6 @@
       "name": "Firefox Marketplace Alt DEV",
       "imageUri": "https://oauth-marketplace.dev.lcip.org/img/logo@2x.png",
       "redirectUri": "https://marketplace-altdev.allizom.org/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -88,7 +82,6 @@
       "name": "Firefox Marketplace Payments Alt DEV",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://payments-alt.allizom.org/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -98,7 +91,6 @@
       "name": "Marketplace Payments Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://payments-alt.allizom.org/mozpay/spa/fxa-auth",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -108,7 +100,6 @@
       "name": "Marketplace Payments Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://mp.dev/mozpay/spa/fxa-auth",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -118,7 +109,6 @@
       "name": "Fireplace Marketplace Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://localhost:8080/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -128,7 +118,6 @@
       "name": "Fireplace Marketplace Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://mp.dev/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -138,7 +127,6 @@
       "name": "Fireplace Marketplace Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8675/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -148,7 +136,6 @@
       "name": "Fireplace Marketplace Comm Dashboard Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8676/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -158,7 +145,6 @@
       "name": "Fireplace Marketplace Stats Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8677/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -168,7 +154,6 @@
       "name": "Fireplace Marketplace Editorial Tools Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8678/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -178,7 +163,6 @@
       "name": "Fireplace Marketplace Operator Dashboard Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8679/fxa-authorize",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -189,7 +173,6 @@
       "name": "FMD Local",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "http://localhost:8000/oauth",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -199,7 +182,6 @@
       "name": "Find My Device Dev",
       "imageUri": "https://marketplace-dev.mozflare.net/media/img/mkt/logos/128.png",
       "redirectUri": "https://find.dev.mozaws.net/oauth",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -210,7 +192,6 @@
       "canGrant": false,
       "id": "24bdbfa45cd300c5",
       "hashedSecret": "dfe56d5c816d6b7493618f6a1567cfed4aa9c25f85d59c6804631c48774ba545",
-      "whitelisted": true,
       "trusted": true
     },
 
@@ -220,7 +201,6 @@
       "hashedSecret": "0000000000000000000000000000000000000000000000000000000000000000",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": true
     },
@@ -230,7 +210,6 @@
       "hashedSecret": "0000000000000000000000000000000000000000000000000000000000000000",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": true
     },
@@ -240,7 +219,6 @@
       "hashedSecret": "0000000000000000000000000000000000000000000000000000000000000000",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": true
     },
@@ -250,7 +228,6 @@
       "hashedSecret": "0000000000000000000000000000000000000000000000000000000000000000",
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": true
     },
@@ -261,7 +238,6 @@
       "canGrant": false,
       "id": "08c0eb0d8c85b964",
       "hashedSecret": "7c4ec2a501bbe7f8779274e58c3f69488f18bd13c6c84996b84047f328743f49",
-      "whitelisted": true,
       "trusted": true
     },
     {
@@ -271,7 +247,6 @@
       "imageUri": "https://location.services.mozilla.com/static/images/mls-logo@2x.png",
       "redirectUri": "http://localhost:8080/auth/complete",
       "canGrant": false,
-      "whitelisted": true,
       "trusted": true
     },
     {
@@ -280,7 +255,6 @@
       "hashedSecret": "97285a0eec1a29bc9f14267251d32fbcaf56dd7f0fb5f1121bcede6b4f11a8ab",
       "imageUri": "",
       "redirectUri": "https://support.mozilla.org/redirects/buddyup-fxa-oauth",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     },
@@ -290,7 +264,6 @@
       "hashedSecret": "13285a0eec1a29bc9f14267251d32fbcaf56dd7f0fb5f1121bcede6b4f11a8cb",
       "imageUri": "",
       "redirectUri": "",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": true
     },
@@ -300,7 +273,6 @@
       "hashedSecret": "ef9b091498b2b1ba01ab4e06993b10393cb059a06a8f33941334ab83f84872f5",
       "imageUri": "",
       "redirectUri": "https://browsercompat.herokuapp.com/accounts/fxa/login/callback/",
-      "whitelisted": true,
       "trusted": true,
       "canGrant": false
     }


### PR DESCRIPTION
It's going away entirely as of https://github.com/mozilla/fxa-oauth-server/pull/284

@jrgm r?