### PR TITLE
chore: Remove "metrics.sample_rate" from fxa-content-server config.

### DIFF
--- a/roles/content/templates/config.json.j2
+++ b/roles/content/templates/config.json.j2
@@ -12,9 +12,6 @@
   "route_log_format": "dev_fxa",
   "static_directory": "dist",
   "page_template_subdirectory": "dist",
-  "metrics" : {
-    "sample_rate" : 1
-  },
   "basket": {
     "proxy_url": "http://127.0.0.1:{{ basket_private_port }}",
     "api_url": "http://127.0.0.1:10140",


### PR DESCRIPTION
The sample rate is now specified by the A/B test infrastructure.

Goes with:
* https://github.com/mozilla/fxa-content-server/pull/2779
* https://github.com/mozilla/fxa-content-experiments/pull/23

This should not merge until both of those PRs have merged.