### PR TITLE
fix(symlink): reverse symlink direction of supervisorctl and virtualenv

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: symlink supervisorctl
   sudo: true
-  file: src=/usr/local/bin/supervisorctl dest=/usr/bin/supervisorctl state=link
+  file: src=/usr/bin/supervisorctl dest=/usr/local/bin/supervisorctl state=link
 
 - file: path=/etc/supervisor.d state=directory
   sudo: true

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: symlink virtualenv
   sudo: true
-  file: src=/usr/local/bin/virtualenv dest=/usr/bin/virtualenv state=link
+  file: src=/usr/bin/virtualenv dest=/usr/local/bin/virtualenv state=link
 
 - name: create syncserver database
   sudo: true


### PR DESCRIPTION
I'm pretty sure this is the correct way. 