### PR TITLE
fix(pip): make pip install virtualenv in /usr/bin

### DIFF
--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -20,11 +20,7 @@
 
 - name: install syncserver build dependencies
   sudo: true
-  pip: name=virtualenv state=present
-
-- name: symlink virtualenv
-  sudo: true
-  file: src=/usr/local/bin/virtualenv dest=/usr/bin/virtualenv state=link
+  pip: name=virtualenv state=present extra_args='--install-option="--install-scripts=/usr/bin"'
 
 - name: create syncserver database
   sudo: true


### PR DESCRIPTION
Nice bit of `pip` magic @dannycoates 

But we also need similar for `virtualenv`, so this is it. 

If I'm wrong again, then just revert me again, but latest.dev.lcip.org is blocked on updates without this 

