### PR TITLE
fix(breakfix): add a placeholder events config to workaround fxa-auth-server#312

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -285,5 +285,9 @@
   "logging": {
     "fmt": "pretty",
     "level": "all"
+  },
+  "events": {
+    "region": "antarctica-west-1",
+    "queueUrl": "https://sqs.antarctica-west-1.amazonaws.com/142069644989/fxa-oauth-events"
   }
 }


### PR DESCRIPTION
https://github.com/mozilla/fxa-oauth-server/pull/312 changed to require an `events` config with non-empty `queueUrl` and `region` if "prod" or "stage". latest.dev.lcip.org runs as "stage" so this breaks all oauth functional tests because the oauth server **will not start on latest.dev.lcip.org**. 

**This is not a fix**, just a band-aid that should get content-server functional tests (mostly) passing again. (Seems to be some other test failures, but at least it gets it back to within shooting distance of passing). 