### PR TITLE
fix(virtualenv): attempt to symlink virtualenv, but ignore errors

### DIFF
--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -22,8 +22,16 @@
   sudo: true
   pip: name=virtualenv state=present
 
+#
+# "legacy" boxes (e.g., 'latest', 'stable', other) have installed `virtualenv`
+# in `/usr/bin` Newer boxes put `virtualenv` in `/usr/local/bin`, but other code
+# wants to find `virtualenv` in `/usr/bin`. So attempt to symlink but ignore
+# failures.
+#
 - name: symlink virtualenv
   sudo: true
+  failed_when: false
+  changed_when: false
   file: src=/usr/local/bin/virtualenv dest=/usr/bin/virtualenv state=link
 
 - name: create syncserver database


### PR DESCRIPTION
@dannycoates - you were right (of course). The pip install of virtualenv does not work with --install-option as expected and keeps putting virtualenv in /usr/local/bin. (I think an upgraded version of pip may fix this bug, but, ugh, what a load of crap).

Anyways, this change will just ignore errors on the symlink. I don't like it a lot, but it solves an immediate problem that `latest.dev.lcip.org` fails to update without this change. 

I also did this by registering the result of `test -f /usr/bin/virtualenv` and only trying the symlink if that file does not already exist. But seemed too much; the symlink is unlikely to fail in the new box case, and it will be quite clear that there's an error when the sync role tries to run virtualenv and can't find it.