### PR TITLE
fix(basket): restart basket-proxy on git change

### DIFF
--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -33,6 +33,8 @@
     - install fxa-content-server dependencies
     - build fxa-content-server assets
     - restart fxa-content-server
+    - restart fxa-basket-proxy
+    - restart fxa-null-basket
 
 - name: configure fxa-content-server
   sudo: true


### PR DESCRIPTION
I realized we weren't restarting the fxa-basket-proxy and fxa-null-basket when the source code changed. This fixes that.

@dannycoates - r?