### PR TITLE
chore(l10n): use production-locales.json

### DIFF
--- a/roles/content/files/fxa-content-server.conf
+++ b/roles/content/files/fxa-content-server.conf
@@ -11,5 +11,5 @@ stdout_logfile_backups=2
 stderr_logfile=/var/log/fxa-content.err
 stderr_logfile_maxbytes=10MB
 stderr_logfile_backups=2
-environment=CONFIG_FILES="/data/fxa-content-server/server/config/awsbox.json,/data/fxa-content-server/server/config/production-experiments.json,/data/fxa-content-server/server/config/local.json"
+environment=CONFIG_FILES="/data/fxa-content-server/server/config/awsbox.json,/data/fxa-content-server/server/config/production-experiments.json,/data/fxa-content-server/server/config/production-locales.json,/data/fxa-content-server/server/config/local.json"
 user=app

--- a/roles/content/templates/config.json.j2
+++ b/roles/content/templates/config.json.j2
@@ -6,9 +6,6 @@
   "env": "production",
   "use_https": false,
   "static_max_age" : 0,
-  "i18n": {
-    "supportedLanguages": ["af", "an", "ar", "as", "ast", "az", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "dsb", "el", "en", "en-GB", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "hsb", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
-  },
   "route_log_format": "dev_fxa",
   "static_directory": "dist",
   "page_template_subdirectory": "dist",


### PR DESCRIPTION
We should be using the list of locales in production-locales.json on `latest.dev.lcip.org` and other test instances of fxa-dev. Travis-ci already tests the full set of possible locales on every commit to fxa-content-server.

r? - @vladikoff 