### PR TITLE
fix(docs): clarify "meta-" prefix for SSH access

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cd aws
 
 To updated the stack just run `make foo` again.
 
-You can ssh into the EC2 instance with `ssh ec2-user@{{ whatever you configured in foo.yml }}`
+You can ssh into the EC2 instance with `ssh ec2-user@meta-{{ whatever you configured in foo.yml }}`
 
 ## Layout Notes
 


### PR DESCRIPTION
I know it's mentioned at the end too, but when did *anyone* read all the way to the end of a readme?