### PR TITLE
Fix ansible playbook location

### DIFF
--- a/aws/Makefile
+++ b/aws/Makefile
@@ -3,4 +3,4 @@
 default: latest
 
 %:
-	ansible-playbook -i localhost, dev.yml --extra-vars "stack_name=$@"
+	PYTHONUNBUFFERED=1 ansible-playbook -i localhost, dev.yml --extra-vars "stack_name=$@"

--- a/aws/roles/cron_update/tasks/main.yml
+++ b/aws/roles/cron_update/tasks/main.yml
@@ -8,9 +8,10 @@
   sudo: true
   service: name=crond state=started enabled=true
 
+# use extra_args to ensure ansible-playbook in in /usr/bin so cron can find it
 - name: install ansible
   sudo: true
-  pip: name=ansible version=1.6.1 state=present
+  pip: name=ansible version=1.6.1 state=present extra_args='--install-option="--install-scripts=/usr/bin"'
 
 - name: install fxa-dev
   sudo: true


### PR DESCRIPTION
Fixes #193 (but not with symlink, force the install into /usr/bin)

1. pip install into /usr/bin

2. ansible/python by default buffers; setting unbuffered prints progress as it happens

r? - @dannycoates or @rfk