### PR TITLE
fix(sqs): create account change queues and subscribe oauth and profile

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -219,15 +219,25 @@
        }
     },
 
-    "FxaBasketQueue": {
+    "FxaOAuthAccountChangeQueue": {
       "Type": "AWS::SQS::Queue"
     },
 
-    "FxaSNSTopic": {
+    "FxaProfileAccountChangeQueue": {
+      "Type": "AWS::SQS::Queue"
+    },
+
+    "FxaBasketAccountChangeQueue": {
+      "Type": "AWS::SQS::Queue"
+    },
+
+    "FxaAccountChangeSNSTopic": {
       "Type" : "AWS::SNS::Topic",
       "Properties" : {
         "Subscription" : [
-           { "Endpoint" : { "Fn::GetAtt" : [ "FxaBasketQueue", "Arn" ] }, "Protocol" : "sqs" }
+          { "Endpoint" : { "Fn::GetAtt" : [ "FxaBasketAccountChangeQueue", "Arn" ] }, "Protocol" : "sqs" },
+          { "Endpoint" : { "Fn::GetAtt" : [ "FxaOAuthAccountChangeQueue", "Arn" ] }, "Protocol" : "sqs" },
+          { "Endpoint" : { "Fn::GetAtt" : [ "FxaProfileAccountChangeQueue", "Arn" ] }, "Protocol" : "sqs" }
         ]
       }
     },
@@ -247,25 +257,25 @@
               "Resource" : "*"
            } ]
         },
-        "Topics" : [ { "Ref" : "FxaSNSTopic" } ]
+        "Topics" : [ { "Ref" : "FxaAccountChangeSNSTopic" } ]
       }
     },
 
-    "FxaBasketQueuePolicy": {
+    "FxaOAuthAccountChangeQueuePolicy": {
       "Type": "AWS::SQS::QueuePolicy",
       "Properties": {
         "PolicyDocument": {
-          "Id": "FxaBasketQueuePolicy",
+          "Id": "FxaOAuthAccountChangeQueuePolicy",
           "Statement": [
             {
-              "Sid": "Allow-SendMessage-To-BasketQueue-From-SNS",
+              "Sid": "Allow-SendMessage-To-OAuthAccountChangeQueue-From-SNS",
               "Effect": "Allow",
               "Principal": {"AWS": "*"},
               "Action":["sqs:SendMessage"],
               "Resource": "*",
               "Condition": {
                 "ArnEquals": {
-                  "aws:SourceArn": { "Ref": "FxaSNSTopic" }
+                  "aws:SourceArn": { "Ref": "FxaAccountChangeSNSTopic" }
                 }
               }
             },
@@ -277,7 +287,67 @@
             }
           ]
         },
-        "Queues": [{ "Ref" : "FxaBasketQueue" }]
+        "Queues": [{ "Ref" : "FxaOAuthAccountChangeQueue" }]
+      }
+    },
+
+    "FxaBasketAccountChangeQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Id": "FxaBasketAccountChangeQueuePolicy",
+          "Statement": [
+            {
+              "Sid": "Allow-SendMessage-To-BasketAccountChangeQueue-From-SNS",
+              "Effect": "Allow",
+              "Principal": {"AWS": "*"},
+              "Action":["sqs:SendMessage"],
+              "Resource": "*",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": { "Ref": "FxaAccountChangeSNSTopic" }
+                }
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": {"AWS": "*"},
+              "Action":["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+              "Resource": "*"
+            }
+          ]
+        },
+        "Queues": [{ "Ref" : "FxaBasketAccountChangeQueue" }]
+      }
+    },
+
+    "FxaProfileAccountChangeQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "PolicyDocument": {
+          "Id": "FxaProfileAccountChangeQueuePolicy",
+          "Statement": [
+            {
+              "Sid": "Allow-SendMessage-To-ProfileAccountChangeQueue-From-SNS",
+              "Effect": "Allow",
+              "Principal": {"AWS": "*"},
+              "Action":["sqs:SendMessage"],
+              "Resource": "*",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": { "Ref": "FxaAccountChangeSNSTopic" }
+                }
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": {"AWS": "*"},
+              "Action":["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+              "Resource": "*"
+            }
+          ]
+        },
+        "Queues": [{ "Ref" : "FxaProfileAccountChangeQueue" }]
       }
     },
 
@@ -392,9 +462,17 @@
       "Description": "RDS Endpoint",
       "Value": {"Fn::GetAtt":[ "FxaRDSInstance", "Endpoint.Address" ]}
     },
-    "BasketQueueURL": {
+    "BasketAccountChangeQueueURL": {
       "Description": "Fxa Account Changes for the Basket API consumer",
-      "Value": { "Ref": "FxaBasketQueue" }
+      "Value": { "Ref": "FxaBasketAccountChangeQueue" }
+    },
+    "OAuthAccountChangeQueueURL": {
+      "Description": "Fxa Account Changes for the OAuth consumer",
+      "Value": { "Ref": "FxaOAuthAccountChangeQueue" }
+    },
+    "ProfileAccountChangeQueueURL": {
+      "Description": "Fxa Account Changes for the Profile consumer",
+      "Value": { "Ref": "FxaProfileAccountChangeQueue" }
     },
     "CustomsBanQueueURL": {
       "Description": "Fxa customs ban queue for use by mozdef",
@@ -402,7 +480,7 @@
     },
     "SNS": {
       "Description": "Fxa Account Changes ARN",
-      "Value": { "Ref": "FxaSNSTopic" }
+      "Value": { "Ref": "FxaAccountChangeSNSTopic" }
     },
     "Redis": {
       "Description": "Fxa Notifications Redis",

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -43,7 +43,9 @@
   vars:
     rds_host: "{{ hostvars['localhost']['stack']['stack_outputs']['RDSEndpoint'] }}"
     auth_sns_arn: "{{ hostvars['localhost']['stack']['stack_outputs']['SNS'] }}"
-    basket_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['BasketQueueURL'] }}"
+    basket_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['BasketAccountChangeQueueURL'] }}"
+    oauth_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['OAuthAccountChangeQueueURL'] }}"
+    profile_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['ProfileAccountChangeQueueURL'] }}"
     customs_ban_queue_url: "{{ hostvars['localhost']['stack']['stack_outputs']['CustomsBanQueueURL'] }}"
     redis_id: "{{ hostvars['localhost']['stack']['stack_outputs']['Redis'] }}"
     authdb_primary_host: "{{ rds_host }}"

--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -287,7 +287,7 @@
     "level": "all"
   },
   "events": {
-    "region": "antarctica-west-1",
-    "queueUrl": "https://sqs.antarctica-west-1.amazonaws.com/142069644989/fxa-oauth-events"
+    "region": "{{ region }}",
+    "queueUrl": "{{ oauth_queue_url }}"
   }
 }

--- a/roles/profile/templates/config.json.j2
+++ b/roles/profile/templates/config.json.j2
@@ -28,5 +28,9 @@
       "maxProcesses": 5
     },
     "url": "{{ profile_public_url }}/a/{id}"
+  },
+  "events": {
+    "region": "{{ region }}",
+    "queueUrl": "{{ profile_queue_url }}"
   }
 }


### PR DESCRIPTION
This creates queues for account change notifications for oauth and profile.

Since it is a documented limitation of Cloudformation that you cannot update the subscriptions to a topic once it has been created, this change effectively deletes the previous account change topic and subscribes basket, oauth and profile servers to it. This causes an interruption for a short bit, which couldn't be done in production, but is acceptable for fxa-dev uses.

r? - @rfk or @dannycoates 