### PR TITLE
[do not merge yet] Newer AMI and optional sizing of instance and disk and some bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 aws/my_vars.yml
 *.swp
+*~

--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -29,19 +29,47 @@
       "NoEcho": "true",
       "MinLength": "8",
       "Description": "RDS password"
+    },
+    "EC2InstanceType": {
+      "Description": "EC2 instance type",
+      "Type": "String",
+      "Default": "t2.small",
+      "AllowedValues": [
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "m3.medium",
+        "m3.large",
+        "m3.xlarge"
+      ],
+      "ConstraintDescription": "must be a valid EC2 instance type."
+    },
+    "EC2VolumeSize": {
+      "Description": "EC2 volume size (GB)",
+      "Type": "String",
+      "Default": "8",
+      "AllowedValues": [
+        "8",
+        "16",
+        "24",
+        "32",
+        "40"
+      ]
     }
   },
 
   "Mappings" : {
     "RegionMap" : {
-      "us-east-1"      : { "AMI" : "ami-fb8e9292" },
-      "us-west-1"      : { "AMI" : "ami-7aba833f" },
-      "us-west-2"      : { "AMI" : "ami-043a5034" },
-      "eu-west-1"      : { "AMI" : "ami-2918e35e" },
-      "sa-east-1"      : { "AMI" : "ami-215dff3c" },
-      "ap-southeast-1" : { "AMI" : "ami-b40d5ee6" },
-      "ap-southeast-2" : { "AMI" : "ami-3b4bd301" },
-      "ap-northeast-1" : { "AMI" : "ami-c9562fc8" }
+      "us-east-1"      : { "AMI" : "ami-60b6c60a" },
+      "us-west-2"      : { "AMI" : "ami-f0091d91" },
+      "us-west-1"      : { "AMI" : "ami-d5ea86b5" },
+      "eu-west-1"      : { "AMI" : "ami-bff32ccc" },
+      "eu-central-1"   : { "AMI" : "ami-bc5b48d0" },
+      "ap-southeast-1" : { "AMI" : "ami-c9b572aa" },
+      "ap-northeast-1" : { "AMI" : "ami-383c1956" },
+      "ap-southeast-2" : { "AMI" : "ami-48d38c2b" },
+      "sa-east-1"      : { "AMI" : "ami-6817af04" }
     }
   },
 
@@ -154,12 +182,21 @@
         "ImageId" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AMI" ]},
         "KeyName" : { "Ref" : "KeyName" },
         "IamInstanceProfile": { "Ref": "FxaInstanceProfile" },
-        "InstanceType" : "m3.medium",
+        "InstanceType" : { "Ref": "EC2InstanceType" },
         "SecurityGroups" : [{ "Ref" : "FxaDevSecurityGroup" }],
         "UserData": { "Fn::Base64": { "Fn::Join": ["",
           ["#!/bin/bash -ex","\n",
           "echo Defaults:ec2-user \\!requiretty >> /etc/sudoers;", "\n"]
-        ]}}
+        ]}},
+        "BlockDeviceMappings" : [
+          {
+            "DeviceName" : "/dev/xvda",
+            "Ebs" : {
+              "VolumeSize" : { "Ref": "EC2VolumeSize" },
+              "VolumeType" : "gp2"
+            }
+          }
+        ]
       }
     },
 

--- a/aws/defaults.yml
+++ b/aws/defaults.yml
@@ -1,0 +1,3 @@
+---
+ec2_instance_type: t2.small
+ec2_volume_size: 8

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -71,8 +71,8 @@
     - memcached
     - datadog
     - customs
-    - authdb
     - auth
+    - authdb
     - content
     - basket-proxy
     - oauth

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -4,6 +4,7 @@
   connection: local
   gather_facts: false
   vars_files:
+    - "defaults.yml"
     - "environments/{{ stack_name }}.yml"
   vars:
     key_name: "{{ stack_name }}-fxadev"
@@ -29,6 +30,8 @@
           Subdomain: "{{ subdomain }}"
           SSLCertificateName: "{{ ssl_certificate_name }}"
           RDSPassword: "{{ rds_password }}"
+          EC2InstanceType: "{{ ec2_instance_type }}"
+          EC2VolumeSize: "{{ ec2_volume_size }}"
         tags:
           Owner: "{{ owner | default('nobody@mozilla.com') }}"
           REAPER_SPARE_ME: "{{ reaper_spare_me | default('false') }}"

--- a/aws/local.yml
+++ b/aws/local.yml
@@ -21,8 +21,8 @@
     - memcached
     - datadog
     - customs
-    - authdb
     - auth
+    - authdb
     - content
     - basket-proxy
     - oauth

--- a/aws/roles/ses/tasks/main.yml
+++ b/aws/roles/ses/tasks/main.yml
@@ -8,6 +8,18 @@
     owner=root group=root mode=0644
   notify: reload postfix
 
+# workaround for python/boto suckage with dotted bucket names
+# https://github.com/boto/boto/issues/2836. Fixed in Ansible > 1.9.
+- name: ensure boto.s3 uses OrdinaryCallingFormat()
+  sudo: true
+  ini_file: dest=/etc/boto.cfg
+     state=present
+     section=s3
+     option=calling_format
+     value=boto.s3.connection.OrdinaryCallingFormat
+     owner=root
+     mode=u=rw,g=r,o=r
+
 - name: get s3 secrets
   sudo: true
   s3: bucket=net.mozaws.ops.hiera-secrets

--- a/roles/authdb/handlers/main.yml
+++ b/roles/authdb/handlers/main.yml
@@ -18,3 +18,7 @@
 - name: restart fxa-auth-db-server
   sudo: true
   supervisorctl: name=fxa-auth-db-server state=restarted
+
+- name: restart fxa-auth-server
+  sudo: true
+  supervisorctl: name=fxa-auth-server state=restarted

--- a/roles/authdb/tasks/main.yml
+++ b/roles/authdb/tasks/main.yml
@@ -13,12 +13,15 @@
     - install fxa-auth-db-mysql mysql-patcher devDependency
     - run db patcher
     - restart fxa-auth-db-server
+    - restart fxa-auth-server
 
 - name: configure fxa-auth-db-server
   sudo: true
   sudo_user: app
   template: src=config.json.j2 dest=/data/fxa-auth-db-mysql/config/stage.json
-  notify: restart fxa-auth-db-server
+  notify: 
+    - restart fxa-auth-db-server
+    - restart fxa-auth-server
 
 - name: supervise fxa-auth-db-server
   sudo: true

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -11,5 +11,8 @@
   notify: restart datadog
   sudo: true
 
-- service: name=datadog-agent state=started
+# use command not service to workaround; fixed in ansible 2.x maybe
+# https://github.com/ansible/ansible-modules-core/issues/1298
+- name: start datadog-agent
+  command: service datadog-agent start
   sudo: true


### PR DESCRIPTION
@dannycoates, @vladikoff - r?

A major set of updates:

- changes the default ec2 instance from m3.medium to t2.small (which counter-intuitively provides better performance in tests I have run, but at a lower cost. The tests also show that they will not run short of CPU credits under typical fxa-dev usage, so no worries about that).

- fixes #174 by inverting the build order of authdb and auth; it's still a bit odd to have authdb peeking at the auth config, but it suffices.

- updates the AMI to use the latest Amazon Linux AMI using HVM (not PV) virtualization.

- the ec2 instance type can now be chosen if t2.small doesn't fit the use case.

- disk size is also now configurable, but almost all use cases of fxa-dev will be fine with the default.

- implicitly updates to boto@2.38.0/python@2.7.10 on the server by moving to the latest amzn AMI.

- works around a couple of problems introduced with boto@2.38.0/python@2.7.10.

NOTE: these updates do mean that I will be rebuilding `latest` and `stage` to switch to the different AMI/etc, so do not merge this PR as I'll need to pick a time for updating those boxes that works with users of those boxes. It also means that any user of fxa-dev who does a `make foo` to update their `foo` box might be surprised that it will be replaced with a new stack. I'm not sure how many folks that is, but will send email to fxa-dev to notify folks ahead of this merging.