### PR TITLE
fix(tags): set Owner and REAPER_SPARE_ME tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ cd aws
 1. Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
 3. create a `environments/foo.yml` file ('foo' can be anything)
   a) see `environments/EXAMPLE.yml` for a base reference
+  b) it is recommended that you set values for `owner` and `reaper_spare_me`
 4. run `make foo`
 
 To updated the stack just run `make foo` again.

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -29,6 +29,9 @@
           Subdomain: "{{ subdomain }}"
           SSLCertificateName: "{{ ssl_certificate_name }}"
           RDSPassword: "{{ rds_password }}"
+        tags:
+          Owner: "{{ owner | default('nobody@mozilla.com') }}"
+          REAPER_SPARE_ME: "{{ reaper_spare_me | default('false') }}"
       register: stack
 
     - debug: var=stack

--- a/aws/environments/EXAMPLE.yml
+++ b/aws/environments/EXAMPLE.yml
@@ -23,3 +23,11 @@ cron_time:
   hour: 0
   day: 1
   month: 1
+
+# The "Reaper" is a service which will shut down long-running instances that
+# have accidentally been left running (but will attempt to notify you and give
+# you lead time before taking any action). To exempt your stack from being
+# someday terminated, set these values. Note: `owner` will default to 
+# "nobody@mozilla.com" reaper_spare_me will default to "false".
+owner: "your.address@mozilla.com"
+reaper_spare_me: "true"

--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -4,3 +4,6 @@ subdomain: latest.dev
 hosted_zone: lcip.org
 ssl_certificate_name: exp20170412_wildcard_dev_lcip.org
 rds_password: 33yJ(Lv)hr6&=N7t
+
+owner: "dev-fxacct@mozilla.org"
+reaper_spare_me: "true"

--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -19,3 +19,6 @@ oauth_git_version: v0.48.1
 profile_git_version: v0.48.0
 rp_git_version: 99a806c3ced0990caf91fed051582f5b2512a498
 oauth_console_git_version: 0.3.8
+
+owner: "dev-fxacct@mozilla.org"
+reaper_spare_me: "true"


### PR DESCRIPTION
Fixes #173 

A tag set on the cloudformation stack will be propagated down to the EC2 instance. 

Defaults to Owner: "nobody@mozilla.com" and REAPER_SPARE_ME: "false", i.e., reap away (when this is in full effect, but it will warn in advance, so it is recommended to set at least Owner to get a warning, or both if you don't want to be reaped).
