### PR TITLE
fix(nginx): use specific route for /.well-known/openid-configuration

### DIFF
--- a/roles/auth/templates/nginx.conf.j2
+++ b/roles/auth/templates/nginx.conf.j2
@@ -5,6 +5,11 @@ location /auth/ {
   proxy_pass http://upstream_auth_server;
 }
 
+# Note: /.well-known/openid-configuration route is defined in
+# ./roles/content/templates/nginx.conf.j2. Most specific route wins, so
+# /.well-known/openid-configuration is handled by the content server, and any
+# other route under /.well-known is handled by the auth server.
+
 location /.well-known/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header Host $http_host;

--- a/roles/content/templates/nginx.conf.j2
+++ b/roles/content/templates/nginx.conf.j2
@@ -4,3 +4,15 @@ location / {
     proxy_redirect off;
     proxy_pass http://upstream_content_server;
 }
+
+# Note: /.well-known/ default route is defined in
+# ./roles/auth/templates/nginx.conf.j2. Most specific route wins, so
+# /.well-known/openid-configuration is handled by the content server, and any
+# other route under /.well-known is handled by the auth server.
+
+location /.well-known/openid-configuration {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://upstream_content_server;
+}


### PR DESCRIPTION
This fixes tests run remotely against latest.dev.lcip.org and other fxa-dev boxes.

r? - @vladikoff, /cc @seanmonstar 