### PR TITLE
fix: csp.reportSampleRate is obsolete and breaks content startup

### DIFF
--- a/roles/content/templates/config.json.j2
+++ b/roles/content/templates/config.json.j2
@@ -16,7 +16,6 @@
   "csp": {
     "enabled": true,
     "reportOnly": true,
-    "reportUri": "/_/csp-violation",
-    "reportSampleRate": 100
+    "reportUri": "/_/csp-violation"
   }
 }


### PR DESCRIPTION
r? - @vladikoff 

Note: latest.dev.lcip.org has not updated fxa-content-server in the last 2 days, since this blocked it.