### PR TITLE
Some fixes to build with node 4.x, and an unrelated error logging change for able and kv

### DIFF
--- a/roles/able/files/able.conf
+++ b/roles/able/files/able.conf
@@ -9,6 +9,8 @@ stopwaitsecs=3
 stdout_logfile=/var/log/able.log
 stdout_logfile_maxbytes=10MB
 stdout_logfile_backups=2
-stderr_logfile=NONE
+stderr_logfile=/var/log/able.err
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=2
 user=app
 environment=NODE_ENV="stage"

--- a/roles/kv/files/fxa-kv-server.conf
+++ b/roles/kv/files/fxa-kv-server.conf
@@ -9,6 +9,8 @@ stopwaitsecs=3
 stdout_logfile=/var/log/fxa-kv.log
 stdout_logfile_maxbytes=10MB
 stdout_logfile_backups=2
-stderr_logfile=NONE
+stderr_logfile=/var/log/fxa-kv.err
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=2
 user=app
 environment=NODE_ENV="stage"

--- a/roles/log/defaults/main.yml
+++ b/roles/log/defaults/main.yml
@@ -1,2 +1,11 @@
 ---
 kibana_public_port: 9199
+
+# The braindead npm phantomjs module insists on having an exact semver match
+# or it tries to install it's own version, and typically fails. Which version
+# of phantomjs is required is determined by which grunt-contrib-* versions
+# require npm phantomjs. Which is hopelessly fragile, and moronic. Phantomjs
+# 1.9.8 seems to be the current required version by the dependencies of
+# `kibana 3.1.3`.
+phantomjs_url: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2
+phantomjs_checksum: "sha1:d29487b2701bcbe3c0a52bc176247ceda4d09d2d"

--- a/roles/log/tasks/main.yml
+++ b/roles/log/tasks/main.yml
@@ -4,6 +4,34 @@
   sudo: true
   yum: name=java-1.7.0-openjdk state=present
 
+# Pre-install `phantomjs`, so npm doesn't try to do this, and fail,
+# leaving `kibana` with a broken mess in ./node_modules. Partially based
+# on https://github.com/nicolai86/ansible-phantomjs.git
+- name: install libfontconfig for phantomjs
+  sudo: true
+  yum: name=fontconfig state=present
+
+- name: check if phantomjs is already installed
+  command: which phantomjs
+  failed_when: false
+  changed_when: false
+  register: has_phantomjs
+
+# In ansible 2.x, you can add 'checksum: "{{ phantomjs_checksum }}"'
+# to ensure tarball integrity. XXX FIXME_WHEN_ANSIBLE_2.0_IS_COMMON
+- name: download phantomjs if necessary
+  get_url: url="{{ phantomjs_url }}" dest="/tmp/phantomjs.tar.bz2"
+  when: has_phantomjs.rc != 0
+
+- name: extract phantomjs into /usr/bin
+  shell: "tar xvjf /tmp/phantomjs.tar.bz2 -C /usr/bin/ --overwrite --wildcards '**/bin/phantomjs' --strip-components=2"
+  sudo: true
+  when: has_phantomjs.rc != 0
+
+- name: ensure /usr/bin/phantomjs is executable
+  file: path=/usr/bin/phantomjs state=file mode=0755
+  when: has_phantomjs.rc != 0
+
 - name: install elasticsearch
   sudo: true
   yum: name=https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.1.1.noarch.rpm state=present

--- a/roles/log/tasks/main.yml
+++ b/roles/log/tasks/main.yml
@@ -20,9 +20,9 @@
 - name: install kibana
   sudo: true
   sudo_user: app
-  git: repo=https://github.com/elasticsearch/kibana.git
+  git: repo=https://github.com/jrgm/kibana.git
        dest=/data/kibana
-       version=v3.1.1
+       version=v3.1.3-plus-uglify-patch-for-node4.x
        force=true
   notify:
     - install kibana dependencies


### PR DESCRIPTION
- The changes to `roles/log` are two-fold:

   1. Use my fork of kibana to fix an issue with grunt and uglify failing to build the assets with nodejs 4.x.

   2. Ensure a version of phantomjs compatible with npm-phantomjs is installed before `npm install` runs. Otherwise, npm-phantomjs would try to install it's own versions, and often fail, breaking the install. I like phantomjs, but can you tell how much I hate this npm module from the comments (and other grunt-contrib-* modules that try to do this sort of tarball-install from npm)?

- The changes to `roles/able` and `roles/kv`, are unrelated to node 4.x. I just had some failures with `npm install` on those roles, but the actual reasons for failing to start were going to /dev/null. So, this just logs the stderr from these services.

I've built new stacks with both nodejs 0.10 and 4.x and passed intern functional tests on 4.x, but this change could be disruptive during the ansible update on an existing stack like latest.dev.lcip.org, or per-person stacks. If it's r+, I'll merge this at a time that I can fix any issues that arise.