### PR TITLE
fxa(latest4): use fxa-dev/master with latest4

### DIFF
--- a/aws/environments/latest4.yml
+++ b/aws/environments/latest4.yml
@@ -12,4 +12,4 @@ node_version: "4.3"
 npm_version: "2.14.18"
 
 fxadev_git_repo: https://github.com/mozilla/fxa-dev.git
-fxadev_git_version: build_with_nodejs_4x
+fxadev_git_version: master


### PR DESCRIPTION
Now that branch build_with_nodejs_4x was merged to master, use master branch on latest4.dev.lcip.org