### PR TITLE
fix(oauth): add display_name permission for untrusted 321done

### DIFF
--- a/roles/rp-untrusted/templates/config.json.j2
+++ b/roles/rp-untrusted/templates/config.json.j2
@@ -8,7 +8,7 @@
   "oauth_uri": "{{ oauth_public_url }}/v1",
   "profile_uri": "{{ profile_public_url }}/v1",
   "content_uri": "{{ content_public_url }}",
-  "scopes": "profile:email profile:uid",
+  "scopes": "profile:email profile:uid profile:display_name",
   "port": {{ rp_untrusted_private_port }},
   "preverify_email_audience": "{{ domain_name }}",
   "preverify_email_jku": "{{ rp_untrusted_public_url }}/.well-known/public-keys",


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/3541#issuecomment-189271094

@shane-tomlinson r?