### PR TITLE
fix(content): install/build in a copy directory and swap back in

### DIFF
--- a/roles/content/handlers/main.yml
+++ b/roles/content/handlers/main.yml
@@ -1,14 +1,40 @@
 ---
 
-- name: install fxa-content-server dependencies
+# To avoid breaking tests by clobbering `dist` from underneath the running
+# content server, we copy the current working directory to a temporary
+# location, do the npm and grunt changes in the copy, and then swap the copy
+# into place (and restart).
+
+# there shouldn't be anything leftover but just in case
+- name: begin install fxa-content-server by removing any leftover in /var/tmp
   sudo: true
   sudo_user: app
-  command: npm install --production chdir=/data/fxa-content-server
+  command: rm -rf /var/tmp/fxa-content-server
+
+- name: begin install fxa-content-server dependencies with a copy
+  sudo: true
+  sudo_user: app
+  command: cp -rpf /data/fxa-content-server /var/tmp
+
+- name: install fxa-content-server dependencies 
+  sudo: true
+  sudo_user: app
+  command: npm install --production chdir=/var/tmp/fxa-content-server
 
 - name: build fxa-content-server assets
   sudo: true
   sudo_user: app
-  command: grunt build chdir=/data/fxa-content-server
+  command: grunt build chdir=/var/tmp/fxa-content-server
+
+- name: remove original /data/fxa-content-server
+  sudo: true
+  sudo_user: app
+  command: rm -rf /data/fxa-content-server
+
+- name: move updated fxa-content-server back into /data
+  sudo: true
+  sudo_user: app
+  command: mv /var/tmp/fxa-content-server /data
 
 - name: restart fxa-content-server
   sudo: true

--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -30,8 +30,12 @@
        version={{ content_git_version }}
        force=true
   notify:
+    - begin install fxa-content-server by removing any leftover in /var/tmp
+    - begin install fxa-content-server dependencies with a copy
     - install fxa-content-server dependencies
     - build fxa-content-server assets
+    - remove original /data/fxa-content-server
+    - move updated fxa-content-server back into /data
     - restart fxa-content-server
 
 - name: configure fxa-content-server


### PR DESCRIPTION
@vladikoff - something like this might be "good enough" to minimize the minutes-long absence of `./dist` during `grunt build`. 

(An alternative approach would be to keep a permanent `/data/fxa-content-server-build`, `rsync` the running copy after the `git pull`, do the build, and then `rsync` the build directory over the running copy and restart).