### PR TITLE
feat(cdn): Deploy static resources to a CDN on a dev.lcip.org domain.

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -24,6 +24,10 @@
       "Type": "String",
       "Description": "SSL Cert name from IAM"
     },
+    "CDNSSLCertificateId": {
+      "Type": "String",
+      "Description": "Cloudfront CDN SSL Cert ID from IAM"
+    },
     "RDSPassword": {
       "Type": "String",
       "NoEcho": "true",
@@ -484,6 +488,14 @@
             "Type": "A",
             "TTL": "30",
             "ResourceRecords" : [ { "Fn::GetAtt" : [ "FxaEc2Instance", "PublicIp" ] } ]
+          },
+          {
+            "Name" : { "Fn::Join" : [ "", ["static-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}, "."]]},
+            "Type": "A",
+            "AliasTarget" : {
+              "HostedZoneId" : "Z2FDTNDATAQYW2",
+              "DNSName" : { "Fn::GetAtt" : [ "FxaCloudfrontPolicy", "DomainName" ] }
+            }
           }
         ]
       }
@@ -493,10 +505,13 @@
       "Type" : "AWS::CloudFront::Distribution",
       "Properties" : {
         "DistributionConfig" : {
+          "Aliases" : [
+              { "Fn::Join" : [ "", ["static-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]}
+          ],
           "DefaultCacheBehavior" : {
               "AllowedMethods" : [ "GET", "HEAD", "OPTIONS" ],
               "Compress" : "true",
-              "TargetOriginId" : { "Fn::Join" : [ "FxaCloudfrontCDN-", [{"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]},
+              "TargetOriginId" : { "Fn::Join" : [ "", ["FxaCloudfrontCDN-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]},
               "ForwardedValues" : {
                   "QueryString" : "false",
                   "Cookies" : { "Forward" : "none" }
@@ -506,14 +521,18 @@
           "Enabled" : "true",
           "Origins" : [ {
               "DomainName" : { "Fn::Join" : [ "", [{"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]},
-              "Id" : { "Fn::Join" : [ "FxaCloudfrontCDN-", [{"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]},
+              "Id" : { "Fn::Join" : [ "", ["FxaCloudfrontCDN-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]},
               "CustomOriginConfig": {
                 "HTTPSPort": "443",
                 "OriginProtocolPolicy": "https-only"
               }
           }],
           "PriceClass" : "PriceClass_All",
-          "ViewerCertificate" : { "CloudFrontDefaultCertificate" : "true" }
+          "ViewerCertificate" : {
+            "IamCertificateId" : {"Ref" : "CDNSSLCertificateId"},
+            "MinimumProtocolVersion": "TLSv1",
+            "SslSupportMethod": "sni-only"
+          }
         }
       }
     }
@@ -555,7 +574,7 @@
     },
     "StaticResourceHost": {
       "Description": "Fxa Static Resource Host",
-      "Value": {"Fn::GetAtt":[ "FxaCloudfrontPolicy", "DomainName" ]}
+      "Value": { "Fn::Join" : [ "", ["static-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]}
     }
   }
 }

--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -561,7 +561,7 @@
               "ForwardedValues" : {
                   "QueryString" : "false",
                   "Cookies" : { "Forward" : "none" },
-                  "Headers": []
+                  "Headers": ["Origin"]
               },
               "ViewerProtocolPolicy" : "https-only"
           },

--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -560,7 +560,8 @@
               "TargetOriginId" : { "Fn::Join" : [ "", ["FxaCloudfrontCDN-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]},
               "ForwardedValues" : {
                   "QueryString" : "false",
-                  "Cookies" : { "Forward" : "none" }
+                  "Cookies" : { "Forward" : "none" },
+                  "Headers": []
               },
               "ViewerProtocolPolicy" : "https-only"
           },

--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -508,6 +508,52 @@
           "Aliases" : [
               { "Fn::Join" : [ "", ["static-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}]]}
           ],
+          "CustomErrorResponses": [
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 400
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 403
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 404
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 405
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 414
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 416
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 500
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 501
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 502
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 503
+            },
+            {
+              "ErrorCachingMinTTL": 0,
+              "ErrorCode": 504
+            }
+          ],
           "DefaultCacheBehavior" : {
               "AllowedMethods" : [ "GET", "HEAD", "OPTIONS" ],
               "Compress" : "true",

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -29,6 +29,7 @@
           HostedZone: "{{ hosted_zone }}"
           Subdomain: "{{ subdomain }}"
           SSLCertificateName: "{{ ssl_certificate_name }}"
+          CDNSSLCertificateId: "{{ cdn_ssl_certificate_id }}"
           RDSPassword: "{{ rds_password }}"
           EC2InstanceType: "{{ ec2_instance_type }}"
           EC2VolumeSize: "{{ ec2_volume_size }}"

--- a/aws/environments/EXAMPLE.yml
+++ b/aws/environments/EXAMPLE.yml
@@ -13,6 +13,7 @@ hosted_zone: lcip.org
 # this must be compatible with your stack_name and hosted_zone
 # see http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingServerCerts.html
 ssl_certificate_name: exp20170412_wildcard_dev_lcip.org
+cdn_ssl_certificate_id: ASCAIAYDJPL5OT7LFEZSE
 
 rds_password: 42{B[3RL(g9ZkE+e
 


### PR DESCRIPTION
* Set up a CNAME to the CDN on static.host.dev.lcip.org
* Tell Cloudfront to use the CNAME
* Tell Cloudfront to use the specified SSL cert

@jrgm, @vladikoff, @dannycoates - I could use some help with this. This patch is to set up the CDN on a dev.lcip.org domain, using our *.dev.lcip.org cert. For the "IamCertificateId", I have tried both the certificate ID for the *.dev.lcip.org cert as reported the AWS CLI, as well as the certificate name. In both cases, the following error is displayed in the AWS console:

```
The specified SSL certificate doesn't exist, isn't valid, or doesn't include a valid certificate chain.
```

I have also tried the Arn, using the [ACMCertificateArn](https://docs.aws.amazon.com/AmazonCloudFront/latest/APIReference/DistributionConfigDatatype.html#DistributionConfigDatatype_Elements) declaration, and instead receive an error along the lines of `ACMCertificateArn is an invalid declaration`.

Any ideas?

fixes #235 