### PR TITLE
fix(customs): increase MAX_ACCOUNT_STATUS_CHECK to 1000

### DIFF
--- a/roles/customs/files/fxa-customs-server.conf
+++ b/roles/customs/files/fxa-customs-server.conf
@@ -12,4 +12,4 @@ stderr_logfile=/var/log/fxa-customs.log
 stderr_logfile_maxbytes=10MB
 stderr_logfile_backups=2
 user=app
-environment=NODE_ENV="stage"
+environment=NODE_ENV="stage",MAX_ACCOUNT_STATUS_CHECK="1000"


### PR DESCRIPTION
r? - @vladikoff @vbudhram 

This value should get tests not failing on 429 errors, so we can see what other test failures exist.

A different number can be picked later.