### PR TITLE
fix(config): Add FxA report-only config options.

### DIFF
--- a/roles/content/templates/config.json.j2
+++ b/roles/content/templates/config.json.j2
@@ -16,7 +16,8 @@
   },
   "csp": {
     "enabled": true,
-    "reportOnly": true,
-    "reportUri": "/_/csp-violation"
+    "reportUri": "/_/csp-violation",
+    "reportOnlyEnabled": true,
+    "reportOnlyUri": "/_/csp-violation-report-only"
   }
 }


### PR DESCRIPTION
Goes along with https://github.com/mozilla/fxa-content-server/pull/3627 and https://github.com/mozilla-services/puppet-config/pull/1988

@vladikoff or @jrgm - r?