### PR TITLE
Use python from $PATH, not system python

### DIFF
--- a/aws/defaults.yml
+++ b/aws/defaults.yml
@@ -1,3 +1,4 @@
 ---
 ec2_instance_type: t2.small
 ec2_volume_size: 8
+ansible_python_interpreter: python


### PR DESCRIPTION
The latest ansible seems to insist on using the system python, rather than the python active in your $PATH at the time it's invoked.  That's no fun when you  don't want to install a bunch of stuff into the crufty old system python on your mac, and would like to use a virtualenv with homebrew instead.

This tweak seems to make it use the python executable found in $PATH, which is much nicer.  I've kicked off a full stack rebuild using this, will update here if it's successful.