### PR TITLE
fix(config): Remove no-longer-supported resendBlackoutPeriod config

### DIFF
--- a/roles/auth/templates/config.json.j2
+++ b/roles/auth/templates/config.json.j2
@@ -18,8 +18,7 @@
         "port": {{ auth_mail_port }},
         "secure": false,
         "sender":"{{ auth_mail_sender }}",
-        "redirectDomain": "firefox.com",
-        "resendBlackoutPeriod": 0
+        "redirectDomain": "firefox.com"
     },
     "listen": {
         "port": {{ auth_private_port }}


### PR DESCRIPTION
@jrgm or @vladikoff r?

Convict freaks out if we have config options that aren't defined, so we have to remove it here.