### PR TITLE
fix(oauth): set connectionLimit: 5 to be less greedy

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -5,7 +5,8 @@
   },
   "mysql": {
     "password": "{{ oauth_db_password }}",
-    "host": "{{ oauth_db_host }}"
+    "host": "{{ oauth_db_host }}",
+    "connectionLimit": 5
   },
   "browserid": {
     "issuer": "{{ browserid_issuer }}"


### PR DESCRIPTION
I've run into it a couple of times where we hit max_connections on an fxa-dev. 

When it hits the limit (32 given the size of RDS instance), 20 of the connections are consumed by the oauth and oauth-internal daemons. I don't think they really need this many connections, but do so because they are configured to grab 10 in a block. So just lower this to something less greedy.
(The other approach is to change max_connections on RDS to something higher, but that requires created a custom parameter list for RDS and using that list with the instance. It's simpler just to have oauth not be so greedy).

r? - @vladikoff or @seanmonstar 