### PR TITLE
feat(client-config): Add support for /.well-known/fxa-client-configuration

### DIFF
--- a/roles/auth/templates/nginx.conf.j2
+++ b/roles/auth/templates/nginx.conf.j2
@@ -5,10 +5,11 @@ location /auth/ {
   proxy_pass http://upstream_auth_server;
 }
 
-# Note: /.well-known/openid-configuration route is defined in
-# ./roles/content/templates/nginx.conf.j2. Most specific route wins, so
-# /.well-known/openid-configuration is handled by the content server, and any
-# other route under /.well-known is handled by the auth server.
+# Note: the following routes are defined in ./roles/content/templates/nginx.conf.j2:
+#  * /.well-known/openid-configuration
+#  * /.well-known/fxa-client-configuration
+# Most specific route wins, so those are handled by the content server,
+# and any other route under /.well-known is handled by the auth server.
 
 location /.well-known/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/roles/content/defaults/main.yml
+++ b/roles/content/defaults/main.yml
@@ -6,6 +6,7 @@ auth_public_url: "{{ public_protocol }}://{{ domain_name }}/auth"
 oauth_domain_name: "oauth-{{ domain_name }}"
 oauth_public_url: "{{ public_protocol }}://{{ oauth_domain_name }}"
 profile_public_url: "{{ public_protocol }}://{{ domain_name }}/profile"
+sync_tokenserver_url: "{{ public_protocol }}://{{ domain_name }}/syncserver/token"
 content_public_url: "{{ public_protocol }}://{{ domain_name }}"
 content_static_resource_url: "{{ public_protocol }}://{{ domain_name }}"
 content_public_port: 80

--- a/roles/content/templates/config.json.j2
+++ b/roles/content/templates/config.json.j2
@@ -3,6 +3,7 @@
   "public_url": "{{ content_public_url }}",
   "oauth_url": "{{ oauth_public_url }}",
   "profile_url": "{{ profile_public_url }}",
+  "sync_tokenserver_url": "{{ sync_tokenserver_url }}",
   "env": "production",
   "use_https": false,
   "static_max_age" : 0,

--- a/roles/content/templates/nginx.conf.j2
+++ b/roles/content/templates/nginx.conf.j2
@@ -7,10 +7,17 @@ location / {
 
 # Note: /.well-known/ default route is defined in
 # ./roles/auth/templates/nginx.conf.j2. Most specific route wins, so
-# /.well-known/openid-configuration is handled by the content server, and any
+# only the below routes are handled by the content server, and any
 # other route under /.well-known is handled by the auth server.
 
 location /.well-known/openid-configuration {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://upstream_content_server;
+}
+
+location /.well-known/fxa-client-configuration {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;


### PR DESCRIPTION
Exposes the `/.well-known/fxa-client-configuration` endpoint that we added in https://github.com/mozilla/fxa-content-server/pull/3919; @vladikoff r?