### PR TITLE
fix(content): add CDN config to environments/latest.yml

### DIFF
--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -10,3 +10,6 @@ ec2_volume_size: 24
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"
+
+cdn_ssl_certificate_id: ASCAIAYDJPL5OT7LFEZSE
+content_static_resource_url: https://static-latest.dev.lcip.org


### PR DESCRIPTION
I ran the update on latest.dev.lcip.org stack so it was actually using a CDN. It also needs this change, to configure content-server to use the CDN. 