### PR TITLE
fix(policy): Update to 2016-8 ELB policy

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -214,7 +214,7 @@
           {
             "InstancePort":"1443",
             "LoadBalancerPort":"443",
-            "PolicyNames" : ["ELBSecurityPolicy-2015-05"],
+            "PolicyNames" : ["ELBSecurityPolicy-2016-08"],
             "Protocol":"HTTPS",
             "SSLCertificateId":{
                "Fn::Join":[ "",


### PR DESCRIPTION
Fixes issue where deploying a new box in the dev AWS account you would get

`There is no policy with name ELBSecurityPolicy-2015-05 for load balancer elb-balancer`