### PR TITLE
fix(notifications): don't do notifications

### DIFF
--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -13,3 +13,6 @@ reaper_spare_me: "true"
 
 cdn_ssl_certificate_id: ASCAIAYDJPL5OT7LFEZSE
 content_static_resource_url: https://static-latest.dev.lcip.org
+
+# If this is not set, no notifications will happen
+notification_publish_url: ""


### PR DESCRIPTION
r? - @rfk 

This may be just for a short-term fix.

The auth-db server is sending larger payloads to the notification server and being rejected. This is spinning a huge amount of CPU and causing other testing to fail.