### PR TITLE
fix(config): fix signinConfirmation.enabledEmailAddresses config

### DIFF
--- a/roles/auth/templates/config.json.j2
+++ b/roles/auth/templates/config.json.j2
@@ -26,7 +26,7 @@
     "signinConfirmation": {
       "enabled": true,
       "sample_rate": 0,
-      "enabledEmailAddresses": "/(^sync.*@restmail.net$|.+@mozilla.com$)/"
+      "enabledEmailAddresses": "^(sync.*@restmail\\.net|.+@mozilla\\.com)$"
     },
     "listen": {
         "port": {{ auth_private_port }}


### PR DESCRIPTION
I didn't explain myself very well about how this config setting gets parsed.

Essentially the string will be passed as the argument to the `RegExp` constructor, so the leading and trailing slashes that got added were wrong. In addition to that I've made a couple more tweaks:

* I've escaped the quoting backslashes so that they make it into the parsed regex, rather than a dot literal which matches any character.

* I've moved the starting `^` and terminating `$` matches outside of the group, to try and make the two types of email a little clearer.

@vladikoff, does this fix the problems you're discussing in https://github.com/mozilla/fxa-content-server/issues/4243?

/cc @jrgm