### PR TITLE
feat(config): Add signinUnblock auth server config (again).

### DIFF
--- a/roles/auth/templates/config.json.j2
+++ b/roles/auth/templates/config.json.j2
@@ -28,6 +28,10 @@
       "sample_rate": 0,
       "enabledEmailAddresses": "^(sync.*@restmail\\.net|.+@mozilla\\.com)$"
     },
+    "signinUnblock": {
+      "enabled": true,
+      "forcedEmailAddresses": "^(block.*@restmail\\.net|.+@mozilla\\.com)$"
+    },
     "listen": {
         "port": {{ auth_private_port }}
     },


### PR DESCRIPTION
This was originally merged as sha
5d58e970e993a63514012bf544e92e2cfb23ef20, but was backed out
because the auth-server portion had not yet merged. The auth-server has
merged, opening again.