### PR TITLE
fix(mailer): Remove the `locales`, depend on fxa-shared

### DIFF
--- a/roles/email/templates/config.json.j2
+++ b/roles/email/templates/config.json.j2
@@ -1,6 +1,5 @@
 {
   "port": {{ auth_mailer_port }},
-  "locales": ["en_US", "de"],
   "contentServer": {
     "url": "{{ content_public_url }}"
   },


### PR DESCRIPTION
The only two locales supported are "en_US" and "de", yet the
defaultLanguage is set to "en". I see a lot of auth-mailer restarts
on fxa-dev when sending verification reminders and am wondering
if this could be a cause.


Instead of using a local set of `locales`, use those from
fxa-shared, which should contain `en` as a language.

@jrgm or @vladikoff - r?