### PR TITLE
fix(auth-server): rename enabledEmailAddresses to forcedEmailAddresses

### DIFF
--- a/roles/auth/templates/config.json.j2
+++ b/roles/auth/templates/config.json.j2
@@ -26,7 +26,7 @@
     "signinConfirmation": {
       "enabled": true,
       "sample_rate": 0,
-      "enabledEmailAddresses": "^(sync.*@restmail\\.net|.+@mozilla\\.com)$"
+      "forcedEmailAddresses": "^(sync.*@restmail\\.net|.+@mozilla\\.com)$"
     },
     "signinUnblock": {
       "enabled": true,


### PR DESCRIPTION
With https://github.com/mozilla/fxa-auth-server/pull/1554,
signinUnblock.enabledEmailAddresses was renamed to forcedEmailAddresses.
We need to update it here too!

@vladikoff, @vbudhram, or @seanmonstar - r?