### PR TITLE
chore(config): remove preverify_email_audience

### DIFF
--- a/roles/rp-untrusted/templates/config.json.j2
+++ b/roles/rp-untrusted/templates/config.json.j2
@@ -10,7 +10,6 @@
   "content_uri": "{{ content_public_url }}",
   "scopes": "profile:email profile:uid profile:display_name",
   "port": {{ rp_untrusted_private_port }},
-  "preverify_email_audience": "{{ domain_name }}",
   "preverify_email_jku": "{{ rp_untrusted_public_url }}/.well-known/public-keys",
   "kv_uri": "{{ kv_public_url }}/v1/data"
 }

--- a/roles/rp/templates/config.json.j2
+++ b/roles/rp/templates/config.json.j2
@@ -10,7 +10,6 @@
   "content_uri": "{{ content_public_url }}",
   "scopes": "profile kv:read kv:write",
   "port": {{ rp_private_port }},
-  "preverify_email_audience": "{{ domain_name }}",
   "preverify_email_jku": "{{ rp_public_url }}/.well-known/public-keys",
   "kv_uri": "{{ kv_public_url }}/v1/data"
 }


### PR DESCRIPTION
These config values are no longer needed, removed in https://github.com/mozilla/123done/pull/158