### PR TITLE
fix(config): update amzn linux ami ids

### DIFF
--- a/aws/cloudformation/basic.json
+++ b/aws/cloudformation/basic.json
@@ -24,14 +24,15 @@
 
   "Mappings" : {
     "RegionMap" : {
-      "us-east-1"      : { "AMI" : "ami-fb8e9292" },
-      "us-west-1"      : { "AMI" : "ami-7aba833f" },
-      "us-west-2"      : { "AMI" : "ami-043a5034" },
-      "eu-west-1"      : { "AMI" : "ami-2918e35e" },
-      "sa-east-1"      : { "AMI" : "ami-215dff3c" },
-      "ap-southeast-1" : { "AMI" : "ami-b40d5ee6" },
-      "ap-southeast-2" : { "AMI" : "ami-3b4bd301" },
-      "ap-northeast-1" : { "AMI" : "ami-c9562fc8" }
+      "us-east-1"      : { "AMI" : "ami-0b33d91d" },
+      "us-west-1"      : { "AMI" : "ami-165a0876" },
+      "us-west-2"      : { "AMI" : "ami-f173cc91" },
+      "eu-west-1"      : { "AMI" : "ami-70edb016" },
+      "eu-central-1"   : { "AMI" : "ami-af0fc0c0" },
+      "ap-southeast-1" : { "AMI" : "ami-dc9339bf" },
+      "ap-northeast-1" : { "AMI" : "ami-56d4ad31" },
+      "ap-southeast-2" : { "AMI" : "ami-dac312b4" },
+      "sa-east-1"      : { "AMI" : "ami-80086dec" }
     }
   },
 

--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -65,15 +65,15 @@
 
   "Mappings" : {
     "RegionMap" : {
-      "us-east-1"      : { "AMI" : "ami-60b6c60a" },
-      "us-west-2"      : { "AMI" : "ami-f0091d91" },
-      "us-west-1"      : { "AMI" : "ami-d5ea86b5" },
-      "eu-west-1"      : { "AMI" : "ami-bff32ccc" },
-      "eu-central-1"   : { "AMI" : "ami-bc5b48d0" },
-      "ap-southeast-1" : { "AMI" : "ami-c9b572aa" },
-      "ap-northeast-1" : { "AMI" : "ami-383c1956" },
-      "ap-southeast-2" : { "AMI" : "ami-48d38c2b" },
-      "sa-east-1"      : { "AMI" : "ami-6817af04" }
+      "us-east-1"      : { "AMI" : "ami-0b33d91d" },
+      "us-west-1"      : { "AMI" : "ami-165a0876" },
+      "us-west-2"      : { "AMI" : "ami-f173cc91" },
+      "eu-west-1"      : { "AMI" : "ami-70edb016" },
+      "eu-central-1"   : { "AMI" : "ami-af0fc0c0" },
+      "ap-southeast-1" : { "AMI" : "ami-dc9339bf" },
+      "ap-northeast-1" : { "AMI" : "ami-56d4ad31" },
+      "ap-southeast-2" : { "AMI" : "ami-dac312b4" },
+      "sa-east-1"      : { "AMI" : "ami-80086dec" }
     }
   },
 


### PR DESCRIPTION
r? - @vladikoff, @rfk 

Updates AMI to most currently available. Only for new servers; existing unaffected.