### PR TITLE
feat(sms): Use a mock SMS provider by default.

### DIFF
--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -19,3 +19,4 @@ auth_mailer_port: 10136
 auth_mailer_verify_url: "{{ content_public_url }}/v1/verify_email"
 auth_mailer_recovery_url: "{{ content_public_url }}/v1/complete_reset_password"
 auth_sms_use_mock: "true"
+auth_sms_geo_enabled: "false"

--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -18,3 +18,4 @@ trusted_jku_321done: "{{ public_protocol }}://321done-{{ domain_name }}/.well-kn
 auth_mailer_port: 10136
 auth_mailer_verify_url: "{{ content_public_url }}/v1/verify_email"
 auth_mailer_recovery_url: "{{ content_public_url }}/v1/complete_reset_password"
+auth_sms_use_mock: "true"

--- a/roles/auth/templates/config.json.j2
+++ b/roles/auth/templates/config.json.j2
@@ -32,5 +32,8 @@
     "listen": {
         "port": {{ auth_private_port }}
     },
-    "snsTopicArn": "{{ auth_sns_arn }}"
+    "snsTopicArn": "{{ auth_sns_arn }}",
+    "sms": {
+      "useMock": {{ auth_sms_use_mock }}
+    }
 }

--- a/roles/auth/templates/config.json.j2
+++ b/roles/auth/templates/config.json.j2
@@ -34,6 +34,7 @@
     },
     "snsTopicArn": "{{ auth_sns_arn }}",
     "sms": {
-      "useMock": {{ auth_sms_use_mock }}
+      "useMock": {{ auth_sms_use_mock }},
+      "isStatusGeoEnabled": {{ auth_sms_geo_enabled }}
     }
 }


### PR DESCRIPTION
This isn't ready, whenever testing on fxa-ci, `useMock` ends up being `True` instead of `true` #305 

fixes mozilla/fxa-content-server#4890