### PR TITLE
fix(docker-gc): removed images unused by any container

### DIFF
--- a/aws/roles/docker-gc/files/docker-gc-images.py
+++ b/aws/roles/docker-gc/files/docker-gc-images.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# docker rmi unused images (not being used by any container)
+# 'Used' means a container based on this image exists, and may
+# be running, or stopped, or paused. If used, the underlying
+# image will not be removed.
+#
+
+import docker
+
+client = docker.from_env()
+
+images = {}
+for image in client.images():
+  images[image['Id']] = image
+
+for container in client.containers():
+  imageId = container['ImageID']
+  if images.get(imageId):
+    images.pop(imageId)
+
+if len(images) == 0:
+  print 'No images need cleanup'
+  exit(0)
+
+for id in images:
+  print 'Removing unused image', images[id]['RepoTags'], images[id]['Id']
+  client.remove_image(images[id])

--- a/aws/roles/docker-gc/tasks/main.yml
+++ b/aws/roles/docker-gc/tasks/main.yml
@@ -1,7 +1,21 @@
 ---
 
-- name: cleanup old docker images
+- name: cleanup dangling docker images
   command: |
     /bin/bash -c "docker images -f 'dangling=true' -q | xargs --no-run-if-empty docker rmi"
+
+- name: install docker-gc-images.py
+  copy:
+    src: docker-gc-images.py
+    dest: /home/ec2-user
+    owner: ec2-user
+    group: ec2-user
+    mode: 0755
+
+- name: cleanup docker images unused by any containers
+  command: /home/ec2-user/docker-gc-images.py
+  register: result
+
+- debug: var=result.stdout_lines
 
 - meta: flush_handlers


### PR DESCRIPTION
r? - @jbuck 

Wrote a simple script to find and remove images unused by any container. As the note in the script says: 'Used means a container based on this image exists, and may be running, or stopped, or paused. If so, the underlying image will not be removed.'