### PR TITLE
fix(sms): do not use "," in environment config lines

### DIFF
--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -71,8 +71,8 @@
       VAPID_KEYS_FILE: "/config/vapid-keys.json"
       CUSTOMS_SERVER_URL: "{{ customs_server_url }}"
       CONTENT_SERVER_URL: "{{ content_public_url }}"
-      SMS_USE_MOCK: "true",
-      SMS_STATUS_GEO_ENABLED: "false",
+      SMS_USE_MOCK: "true"
+      SMS_STATUS_GEO_ENABLED: "false"
       SMTP_HOST: "{{ auth_mail_host }}"
       SMTP_PORT: "{{ auth_mail_port }}"
       # This MUST be quoted. Otherwise, it becomes pythonic False,


### PR DESCRIPTION
r? - @vladikoff 

I had the syntax wrong in the previous commit, duh.