### PR TITLE
fix(SMS): Relax MAX_ACCOUNT_ACCESS for functional tests.

### DIFF
--- a/roles/customs/files/fxa-customs-server.conf
+++ b/roles/customs/files/fxa-customs-server.conf
@@ -12,4 +12,4 @@ stderr_logfile=/var/log/fxa-customs.log
 stderr_logfile_maxbytes=10MB
 stderr_logfile_backups=2
 user=app
-environment=NODE_ENV="stage",MAX_ACCOUNT_STATUS_CHECK="1000",UID_RATE_LIMIT="1000"
+environment=NODE_ENV="stage",MAX_ACCOUNT_ACCESS="1000",MAX_ACCOUNT_STATUS_CHECK="1000",UID_RATE_LIMIT="1000"


### PR DESCRIPTION
The functional tests that consume signinCodes are being rate limited.
Relax the limit on test environments.

@philbooth - Is this the right field to get around the SMS signinCode consumption rate limiting we saw?