### PR TITLE
fix(db-patcher): Use correct docker tag when running db-patcher script.

### DIFF
--- a/roles/authdb/tasks/main.yml
+++ b/roles/authdb/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: run db_patcher
   become: true
-  command: docker run --rm --net=host -e NODE_ENV=stage mozilla/fxa-auth-db-mysql node bin/db_patcher.js
+  command: docker run --rm --net=host -e NODE_ENV=stage mozilla/fxa-auth-db-mysql{{ ':' + authdb_docker_tag }} node bin/db_patcher.js
 
 - name: Start auth-db docker container
   become: true


### PR DESCRIPTION
Otherwise you can't deploy a `feature.name` branch of auth-db-mysql that contains a migration, because we run the db-patcher script from the `latest` tag rather than `feature.name`.