### PR TITLE
fix(client): Add iOS dev oauth client

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -285,6 +285,15 @@
       "redirectUri": "https://example2.domain/return?foo=bar",
       "trusted": true,
       "canGrant": true
+    },
+    {
+      "id": "1b1a3e44c54fbb58",
+      "hashedSecret": "894669f8a640e824a52e268d51d7732b1b77267300a11cc77145ad0ef81a0c17",
+      "name": "Firefox Accounts Dev iOS",
+      "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
+      "redirectUri": "",
+      "trusted": true,
+      "canGrant": true
     }
   ],
   "env": "stage",


### PR DESCRIPTION
This adds a randomly generated oauth client for iOS. Connects with https://github.com/mozilla/fxa-oauth-server/issues/473

@rfk @vladikoff r?