### PR TITLE
fix(rp): Update 123done config to new, simpler set of entries.

### DIFF
--- a/roles/rp-untrusted/templates/config.json.j2
+++ b/roles/rp-untrusted/templates/config.json.j2
@@ -1,15 +1,8 @@
 {
-  "publicKeyFile": "/config/public-key.json",
-  "secretKeyFile": "/config/secret-key.json",
   "client_id": "325b4083e32fe8e7",
   "client_secret": "a084f4c36501ea1eb2de33258421af97b2e67ffbe107d2812f4a14f3579900ef",
   "redirect_uri": "{{ rp_untrusted_public_url }}/api/oauth",
-  "auth_uri": "{{ oauth_public_url }}/v1/authorization",
-  "oauth_uri": "{{ oauth_public_url }}/v1",
-  "profile_uri": "{{ profile_public_url }}/v1",
-  "content_uri": "{{ content_public_url }}",
-  "scopes": "profile:email profile:uid profile:display_name",
-  "port": {{ rp_untrusted_private_port }},
-  "preverify_email_jku": "{{ rp_untrusted_public_url }}/.well-known/public-keys",
-  "kv_uri": "{{ kv_public_url }}/v1/data"
+  "issuer_uri": "{{ content_public_url }}",
+  "scopes": "profile:email profile:uid profile:display_name openid",
+  "port": {{ rp_untrusted_private_port }}
 }

--- a/roles/rp/templates/config.json.j2
+++ b/roles/rp/templates/config.json.j2
@@ -1,15 +1,8 @@
 {
-  "publicKeyFile": "/config/public-key.json",
-  "secretKeyFile": "/config/secret-key.json",
   "client_id": "dcdb5ae7add825d2",
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
   "redirect_uri": "{{ rp_public_url }}/api/oauth",
-  "auth_uri": "{{ oauth_public_url }}/v1/authorization",
-  "oauth_uri": "{{ oauth_public_url }}/v1",
-  "profile_uri": "{{ profile_public_url }}/v1",
-  "content_uri": "{{ content_public_url }}",
-  "scopes": "profile kv:read kv:write",
-  "port": {{ rp_private_port }},
-  "preverify_email_jku": "{{ rp_public_url }}/.well-known/public-keys",
-  "kv_uri": "{{ kv_public_url }}/v1/data"
+  "issuer_uri": "{{ content_public_url }}",
+  "scopes": "profile openid",
+  "port": {{ rp_private_port }}
 }


### PR DESCRIPTION
As of https://github.com/mozilla/123done/pull/165 the config for 123done has been greatly simplified, you know only need to specify a single "issuer uri" rather than listing all the services.  @mozilla/fxa-devs r?