### PR TITLE
Update auth-server redirect domain

### DIFF
--- a/aws/environments/fxaci.yml
+++ b/aws/environments/fxaci.yml
@@ -11,3 +11,4 @@ ec2_volume_size: 24
 fxadev_git_version: docker
 
 content_public_url: "http://127.0.0.1:3030"
+auth_redirect_domain: "127.0.0.1"

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -81,7 +81,7 @@
       SMTP_SECURE: "false"
       SMTP_SENDER: "{{ auth_mail_sender }}"
       SECONDARY_EMAIL_ENABLED: "true"
-      REDIRECT_DOMAIN: "firefox.com"
+      REDIRECT_DOMAIN: "{{ auth_redirect_domain | default('firefox.com')}}"
       SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX: "^(sync.*@restmail\\.net)$"
       SIGNIN_UNBLOCK_FORCED_EMAILS: "^(block.*@restmail\\.net)$"
       IP_PROFILING_RECENCY: "{{ auth_ip_profiling_recency | default('0') }}"


### PR DESCRIPTION
This PR updates the `REDIRECT_DOMAIN` env in fxaci to support In https://github.com/mozilla/fxa-content-server/pull/5922. In that PR we use the `redirectTo` param to redirect back to the original settings panel after a user has verified their email address. The auth-server rejects requests because redirect domain is `127.0.0.1`.

This was tested in https://github.com/mozilla/fxa-dev/tree/docker-vbudhram and the corresponding tests pass.

@mozilla/fxa-devs r?