### PR TITLE
chore(rds): remove unreferenced rds_password from aws/environment's

### DIFF
--- a/aws/environments/EXAMPLE.yml
+++ b/aws/environments/EXAMPLE.yml
@@ -14,7 +14,7 @@ hosted_zone: lcip.org
 # ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
 ssl_certificate_arn: arn:aws:acm:us-east-1:927034868273:certificate/675e0ac8-23af-4153-8295-acb28ccc9f0f
 
-rds_password: 42{B[3RL(g9ZkE+e
+
 
 # how often to auto-update (defaults to every 10 minutes)
 # the example below will set it to only update on January 1, 00:00 UTC

--- a/aws/environments/ampy.yml
+++ b/aws/environments/ampy.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: ampy.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 33yJ(Lv)hr6&=N7t
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/content.yml
+++ b/aws/environments/content.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: content.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 33yJ(Lv)hr6&=N7t
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/dcoates.yml
+++ b/aws/environments/dcoates.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: dcoates.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 3s,hE2;QDw?6)t8e
+
 auth_git_repo: https://github.com/dannycoates/picl-idp.git
 auth_git_version: ab-test
 rp_git_repo: https://github.com/dannycoates/123done.git

--- a/aws/environments/emails3.yml
+++ b/aws/environments/emails3.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: emails3.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/featurebox.yml
+++ b/aws/environments/featurebox.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: featurebox.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/fxaci.yml
+++ b/aws/environments/fxaci.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: fxaci.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/fxadevtest.yml
+++ b/aws/environments/fxadevtest.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: fxadevtest.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/ios-push.yml
+++ b/aws/environments/ios-push.yml
@@ -11,7 +11,7 @@ hosted_zone: lcip.org
 
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
 
-rds_password: 3f3449779fbe896ed91398f4b56b6257
+
 
 # how often to auto-update (defaults to every 10 minutes)
 # the example below will set it to only update on January 1, 00:00 UTC

--- a/aws/environments/jrgm2.yml
+++ b/aws/environments/jrgm2.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: jrgm2.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 33yJ(Lv)hr6&=N7t
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: latest.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 33yJ(Lv)hr6&=N7t
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/latest4.yml
+++ b/aws/environments/latest4.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: latest4.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 33yJ(Lv)hr6&=N7t
+
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"

--- a/aws/environments/latest6.yml
+++ b/aws/environments/latest6.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: latest6.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 33yJ(Lv)hr6&=N7t
+
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"

--- a/aws/environments/latestd.yml
+++ b/aws/environments/latestd.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: latestd.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 33yJ(Lv)hr6&=N7t
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/marketplace.yml
+++ b/aws/environments/marketplace.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: marketplace.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: r44?%Wuj8y$BJ,B3
+
 cron_time:
   minute: 0
   hour: 0

--- a/aws/environments/nightly.yml
+++ b/aws/environments/nightly.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: nightly.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: QK4L6(8ZXoT$y{2&
+
 cron_time:
   minute: 5
   hour: 10

--- a/aws/environments/oauth-sync.yml
+++ b/aws/environments/oauth-sync.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: oauth-sync.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 3f3449779fbe896ed91398f4b56b6257
+
 owner: "rfkelly@mozilla.com"
 reaper_spare_me: "true"
 content_docker_tag: feature.oauth-sync

--- a/aws/environments/rfkelly.yml
+++ b/aws/environments/rfkelly.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: rfkelly.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: 3f3449779fbe896ed91398f4b56b6257
+
 owner: "rfkelly@mozilla.com"
 reaper_spare_me: "true"
 auth_docker_tag: feature.amr-info

--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: stable.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: Q&}PzHU79J8Ex}3,
+
 cron_time:
   minute: 0
   hour: 0

--- a/aws/environments/stable2.yml
+++ b/aws/environments/stable2.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: stable2.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: unused
+
 cron_time:
   minute: 0
   hour: 0

--- a/aws/environments/stomlinson.yml
+++ b/aws/environments/stomlinson.yml
@@ -20,7 +20,7 @@ fxadev_git_version: docker
 ec2_instance_type: t2.medium
 ec2_volume_size: 24
 
-rds_password: 42{B[3RL(g9ZkE+e
+
 
 # how often to auto-update (defaults to every 10 minutes)
 # the example below will set it to only update on January 1, 00:00 UTC

--- a/aws/environments/test1.yml
+++ b/aws/environments/test1.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: test1.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/test2.yml
+++ b/aws/environments/test2.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: test2.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/test3.yml
+++ b/aws/environments/test3.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: test3.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/test62.yml
+++ b/aws/environments/test62.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: test62.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/totp.yml
+++ b/aws/environments/totp.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: totp.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/udara.yml
+++ b/aws/environments/udara.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: udara.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/ux.yml
+++ b/aws/environments/ux.yml
@@ -3,7 +3,7 @@ region: us-west-2
 subdomain: ux.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24

--- a/aws/environments/uxwip.yml
+++ b/aws/environments/uxwip.yml
@@ -3,6 +3,6 @@ region: us-west-2
 subdomain: uxwip.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: Q)vy7]e9Q8G%9f{K
+
 
 content_git_version: issue-2336-new-settings-page

--- a/aws/environments/vbudhram.yml
+++ b/aws/environments/vbudhram.yml
@@ -3,4 +3,4 @@ region: us-west-2
 subdomain: vbudhram.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
-rds_password: ab4b6475c68a8734
+


### PR DESCRIPTION
r? - @rfk 

`rds_password` is no longer used in the docker branch (not to mention that the databases have no sensitive data or that they can't be accessed externally). So just cleaning these out. 
