### PR TITLE
fix(123done): make 123done restart to pick up config file changes

### DIFF
--- a/roles/rp-untrusted/tasks/main.yml
+++ b/roles/rp-untrusted/tasks/main.yml
@@ -32,6 +32,8 @@
     command: node ./server.js
     env:
       CONFIG_123DONE: "/config/config-dev.json"
+      # this environment variable was added to force a restart and can be removed
+      HACKS_R_US: "true"
     volumes:
       - /data/config/rp-untrusted:/config
   register: container

--- a/roles/rp/tasks/main.yml
+++ b/roles/rp/tasks/main.yml
@@ -45,6 +45,8 @@
     command: node ./server.js
     env:
       CONFIG_123DONE: "/config/config-dev.json"
+      # this environment variable was added to force a restart and can be removed
+      HACKS_R_US: "true"
     volumes:
       - /data/config/rp:/config
   register: container


### PR DESCRIPTION
So, 123done loads the config file direct from disk (i.e., no convict-style reader). And there's no handler on the template change. I could add the handler but it would be better to teach 123done to use the environment. 

Anyways, in the short term, adding a new env var will cause 123done to restart and pick up the new config on `latest` and other fxa-dev boxes.

r? - @vladikoff 