### PR TITLE
Update auth-server redirect domain

### DIFF
--- a/aws/environments/fxaci.yml
+++ b/aws/environments/fxaci.yml
@@ -11,3 +11,4 @@ ec2_volume_size: 24
 fxadev_git_version: docker-skipForNewAccounts
 
 content_public_url: "http://127.0.0.1:3030"
+auth_redirect_domain: "127.0.0.1"

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -154,7 +154,7 @@
       SMTP_SENDER: "{{ auth_mail_sender }}"
       SECONDARY_EMAIL_ENABLED: "true"
       SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS: "true"
-      REDIRECT_DOMAIN: "firefox.com"
+      REDIRECT_DOMAIN: "{{ auth_redirect_domain | default('firefox.com')}}"
       VERIFICATION_REMINDER_RATE: 1
       SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX: "^sync.*@restmail\\.net$"
       SIGNIN_UNBLOCK_FORCED_EMAILS: "^block.*@restmail\\.net$"


### PR DESCRIPTION
@vladikoff r?

What would happen if we pointed `fxadev_git_version` to docker branch? Seems like without that, we are running a few updates behind.