### PR TITLE
feat(keys): Allow configuration of SCOPED_KEYS_VALIDATION object.

### DIFF
--- a/aws/environments/oauth-sync.yml
+++ b/aws/environments/oauth-sync.yml
@@ -8,3 +8,27 @@ owner: "rfkelly@mozilla.com"
 reaper_spare_me: "true"
 content_docker_tag: feature.oauth-sync
 sync_docker_tag: feature.oauth-sync
+
+# N.B. the leading newline on the value below is important,
+# it prevents ansible from parsing it as a python dict.
+content_scoped_keys_validation: >-
+
+  {
+    "https://identity.mozilla.com/apps/lockbox": {
+      "redirectUris": [
+        "https://2aa95473a5115d5f3deb36bb6875cf76f05e4c4d.extensions.allizom.org/",
+        "https://mozilla-lockbox.github.io/fxa/ios-redirect.html"
+      ]
+    },
+    "https://identity.mozilla.com/apps/notes": {
+      "redirectUris": [
+        "https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org/",
+        "https://mozilla.github.io/notes/fxa/android-redirect.html"
+      ]
+    },
+    "https://identity.mozilla.com/apps/oldsync": {
+      "redirectUris": [
+        "http://localhost:13131/oauth/complete"
+      ]
+    }
+  }

--- a/roles/content/defaults/main.yml
+++ b/roles/content/defaults/main.yml
@@ -15,3 +15,21 @@ content_git_repo: https://github.com/mozilla/fxa-content-server.git
 content_git_version: master
 content_docker_tag: latest
 content_docker_state: started
+# N.B. the leading newline on the value below is important,
+# it prevents ansible from parsing it as a python dict.
+content_scoped_keys_validation: >-
+
+  {
+    "https://identity.mozilla.com/apps/lockbox": {
+       "redirectUris": [
+         "https://2aa95473a5115d5f3deb36bb6875cf76f05e4c4d.extensions.allizom.org/",
+         "https://mozilla-lockbox.github.io/fxa/ios-redirect.html"
+       ]
+     },
+     "https://identity.mozilla.com/apps/notes": {
+       "redirectUris": [
+         "https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org/",
+         "https://mozilla.github.io/notes/fxa/android-redirect.html"
+       ]
+     }
+  }

--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -49,6 +49,7 @@
       FXA_MARKETING_EMAIL_API_URL: "{{ content_public_url }}/basket"
       FXA_MARKETING_EMAIL_PREFERENCES_URL: "https://www-dev.allizom.org/newsletter/existing/"
       SCOPED_KEYS_ENABLED: 'true'
+      SCOPED_KEYS_VALIDATION: "{{ content_scoped_keys_validation }}"
   register: container
 
 - debug: var=container


### PR DESCRIPTION
This allows the scoped-keys validation rules to be customized for each dev environment, based on an environment variable.  @vladikoff r?

This took me a lot longer than it should have, because something down inside ansible likes to parse strings starting with "{" into python dicts and then re-render them as strings which are *almost* JSON except for using single quotes and so are rejected by `JSON.parse`.  Causing the string to not start with "{" was the nicest solution I could come up with...