### PR TITLE
feat(sms): enable permissions for SMS budget checks

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -164,7 +164,9 @@
                    "sqs:DeleteMessage"
                  ],
                  "Resource": { "Fn::GetAtt" : [ "FxaProfileUpdateQueue", "Arn" ] }
-               }
+               },
+               { "Effect":"Allow", "Action": [ "SNS:GetSMSAttributes" ], "Resource": "*" },
+               { "Effect":"Allow", "Action": [ "Cloudwatch:GetMetricStatistics" ], "Resource": "*" }
              ]
             }
           }


### PR DESCRIPTION
As per the discussion at https://github.com/mozilla/fxa-auth-server/pull/2401#issuecomment-384965557, this PR adds permissions to query AWS for our current spend against the budget.

Tested in the [`sms` branch](https://github.com/mozilla/fxa-dev/compare/docker...sms?expand=1) and running right now as `sms.dev.lcip.org`.

@jbuck r?