### PR TITLE
fix(auth): must quote "{{ domain_name }}"

### DIFF
--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -12,4 +12,5 @@ owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"
 
 content_static_resource_url: https://static-latest.dev.lcip.org
-auth_redirect_domain: {{ domain_name }}
+auth_redirect_domain: "{{ domain_name }}"
+


### PR DESCRIPTION
`"{{ domain_name }}"` must be quoted, else syntax error.

But changing it just for latest seems unsymmetric. Isn't `domain_name` the natural default for `auth_redirect_domain` on any fxa-dev box (and where an override is needed that can be done by setting `auth_redirect_domain` to a literal value as in #366?

But this one is needed now, otherwise `latest` will not autoupdate.

