### PR TITLE
fix(123done): build 123done docker image in place, as needed, from github

### DIFF
--- a/aws/docker-pull.sh
+++ b/aws/docker-pull.sh
@@ -4,7 +4,6 @@
 # if changed subseqsently.
 
 IMAGES=(
-  jrgm/123done
   mozilla/browserid-verifier
   mozilla/fxa-auth-db-mysql
   mozilla/fxa-auth-server

--- a/aws/environments/jrgm.yml
+++ b/aws/environments/jrgm.yml
@@ -4,9 +4,10 @@ subdomain: jrgm.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
 
-
 ec2_instance_type: t2.medium
 ec2_volume_size: 24
+fxadev_git_version: docker-build-123done
+rp_git_version: oauth-build-123done
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"

--- a/aws/local.yml
+++ b/aws/local.yml
@@ -28,6 +28,7 @@
     - auth
     - content
     - basket-proxy
+    - rp-build
     - rp
     - rp-untrusted
     - oauth

--- a/roles/rp-build/defaults/main.yml
+++ b/roles/rp-build/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+rp_git_repo: https://github.com/mozilla/123done.git
+rp_git_version: oauth
+rp_docker_tag: latest

--- a/roles/rp-build/handlers/main.yml
+++ b/roles/rp-build/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: build 123done docker image
+  become: true
+  docker_image:
+    state: present
+    force: true
+    path: /data/123done
+    name: mozilla/123done
+    tag: "{{ rp_docker_tag }}"
+  register: image
+
+- debug: var=image

--- a/roles/rp-build/meta/main.yml
+++ b/roles/rp-build/meta/main.yml
@@ -2,4 +2,3 @@
 dependencies:
   - { role: common }
   - { role: web }
-  - { role: rp-build }

--- a/roles/rp-build/tasks/main.yml
+++ b/roles/rp-build/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+# Pulls github.com/mozilla/123done and creates a docker build image from it.
+# This role must run before roles rp and rp-untrusted. The docker_container
+# module will detect if/when the docker image has changed, and will restart
+# the container as needed. @see ../../rp/tasks and ../../rp-untrusted/tasks.
+
+- name: git pull mozilla/123done
+  tags: code
+  become: true
+  git: repo={{ rp_git_repo }}
+       dest=/data/123done
+       version={{ rp_git_version }}
+       force=true
+  notify:
+    - build 123done docker image
+
+- meta: flush_handlers

--- a/roles/rp-untrusted/meta/main.yml
+++ b/roles/rp-untrusted/meta/main.yml
@@ -2,4 +2,5 @@
 dependencies:
   - { role: common }
   - { role: web }
+  - { role: rp-build }
   - { role: rp }

--- a/roles/rp-untrusted/tasks/main.yml
+++ b/roles/rp-untrusted/tasks/main.yml
@@ -14,13 +14,23 @@
   become_user: app
   template: src=config.json.j2 dest=/data/config/rp-untrusted/config-dev.json
 
-# rely on the 123done image having already been pulled by the rp role
+# Relies on the rp-build role to create the mozilla/123done image.
 
-- name: Start 123done docker container as untrusted rp
+# Note: container renamed to `rp2-untrusted` so that existing fxa-dev boxes
+# will remove the currently running container named `rp-untrusted` and
+# `rp2-untrusted` will not fail to bind on the listening tcp port number.
+
+- name: Ensure removal of existing `rp-untrusted` container.
   become: true
   docker_container:
     name: rp-untrusted
-    image: jrgm/123done{{ ':' + rp_docker_tag }}
+    state: absent
+
+- name: Start 123done docker container as rp2-untrusted
+  become: true
+  docker_container:
+    name: rp2-untrusted
+    image: mozilla/123done{{ ':' + rp_docker_tag }}
     state: "{{ rp_docker_state }}"
     network_mode: host
     ports:

--- a/roles/rp/defaults/main.yml
+++ b/roles/rp/defaults/main.yml
@@ -5,7 +5,6 @@ domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 rp_private_port: 4900
 rp_git_repo: https://github.com/mozilla/123done.git
 rp_git_version: oauth
-rp_docker_tag: latest
 rp_docker_state: started
 rp_domain_name: "123done-{{ domain_name }}"
 rp_public_url: "{{ public_protocol }}://{{ rp_domain_name }}"

--- a/roles/rp/tasks/main.yml
+++ b/roles/rp/tasks/main.yml
@@ -14,26 +14,23 @@
   become_user: app
   template: src=config.json.j2 dest=/data/config/rp/config-dev.json
 
-- name: pull 123done docker image
-  become: true
-  docker_image:
-    # pull image always. In a pending update to ansible, it will only set
-    # changed:true if the image has actually changed. However, docker_container
-    # `state:started` will only re-start if image of configuration has
-    # changed.
-    force: true
-    state: present
-    name: jrgm/123done
-    tag: "{{ rp_docker_tag }}"
-  register: image
+# Relies on the rp-build role to create the mozilla/123done image.
 
-- debug: var=image
+# Note: container renamed to `rp2` so that existing fxa-dev boxes will remove
+# the currently running container named `rp` and `rp2` will not fail to bind
+# on the listening tcp port number.
 
-- name: Start 123done docker container as trusted rp
+- name: Ensure removal of existing `rp` container.
   become: true
   docker_container:
     name: rp
-    image: jrgm/123done{{ ':' + rp_docker_tag }}
+    state: absent
+
+- name: Start 123done docker container as trusted rp2
+  become: true
+  docker_container:
+    name: rp2
+    image: mozilla/123done{{ ':' + rp_docker_tag }}
     state: "{{ rp_docker_state }}"
     network_mode: host
     ports:


### PR DESCRIPTION
Setting up with dockerhub was not going to be straightforward (security concerns about write access of the integration), so I went this way instead - add a role to pull from github and build the docker image on the fxa-dev instance. This will also remove the existing 123done containers on `latest` and other existing boxes, replacing them with containers from the new image. 

When changes are pushed to mozilla/123done, I've tested that the image changes are picked up, and that if `rp|rp-untrusted` containers exist, they are retired. 

Teamcity tests do as well as they do against `latest` with the current set of images, with a handful or less of test failures.

(Ignore the change to `aws/environments/jrgm.yml`; it's just for testing).

Fixes https://github.com/mozilla/fxa-dev/issues/359, r? - @vladikoff @mozilla/fxa-devs 

Maybe just review, but not merge this; I can merge and check that `latest` does the right thing and retires the existing `rp.*` containers without error.