### PR TITLE
fix(database): optionally allow provisioning and use of RDS

### DIFF
--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -62,6 +62,17 @@
         "32",
         "40"
       ]
+    },
+    "RDSPassword": {
+      "Type": "String",
+      "Description": "RDS password",
+      "NoEcho": "true"
+    },
+    "UseRDS": {
+      "Description": "Create and use an RDS database?",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues": [ "true", "false" ]
     }
   },
 
@@ -77,6 +88,10 @@
       "ap-southeast-2" : { "AMI" : "ami-dac312b4" },
       "sa-east-1"      : { "AMI" : "ami-80086dec" }
     }
+  },
+
+  "Conditions" : {
+    "UseRDS" : { "Fn::Equals" : [{ "Ref" : "UseRDS" }, "true" ]}
   },
 
   "Resources" : {
@@ -205,8 +220,23 @@
             "\n", "rm -rf /data/fxa-dev",
             "\n", "time git clone -b ", { "Ref": "BranchName"  }, " git://github.com/mozilla/fxa-dev.git /data/fxa-dev",
             "\n", "time service docker start",
-            "\n", "date",
             "\n", "time /data/fxa-dev/aws/docker-pull.sh",
+            "\n", "",
+            "\n", "export RDS_ENDPOINT=", { "Fn::If" : [ "UseRDS", { "Fn::GetAtt": [ "FxaRDSInstance", "Endpoint.Address" ]}, "" ] },
+            "\n", "if [ ! -z ${RDS_ENDPOINT} ]; then",
+            "\n", "  echo rds_password: ",             { "Ref": "RDSPassword" }, " >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo authdb_primary_password: ",  { "Ref": "RDSPassword" }, " >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo authdb_replica_password: ",  { "Ref": "RDSPassword" }, " >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo oauth_db_password: ",        { "Ref": "RDSPassword" }, " >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo profile_db_password: ",      { "Ref": "RDSPassword" }, " >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo authdb_primary_host: ${RDS_ENDPOINT} >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo authdb_replica_host: ${RDS_ENDPOINT} >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo oauth_db_host:       ${RDS_ENDPOINT} >> /data/fxa-dev/rds-remote.yml",
+            "\n", "  echo profile_db_host:     ${RDS_ENDPOINT} >> /data/fxa-dev/rds-remote.yml",
+            "\n", "else",
+            "\n", "  echo 'this_space: for_rent' >> /data/fxa-dev/rds-remote.yml",
+            "\n", "fi",
+            "\n", "",
             "\n", "su - ec2-user -c '",
             "cd /data/fxa-dev/aws && PYTHONUNBUFFERED=1 time ansible-playbook -i localhost, local.yml",
             " -e fxadev_git_version=",       { "Ref": "BranchName" },
@@ -217,6 +247,7 @@
             " -e profile_queue_url=",        { "Ref": "FxaProfileAccountChangeQueue" },
             " -e profile_update_queue_url=", { "Ref": "FxaProfileUpdateQueue" },
             " -e customs_ban_queue_url=",    { "Ref": "FxaCustomsBanQueue" },
+            " -e @/data/fxa-dev/rds-remote.yml",
             "  | /usr/bin/ts %T",
             "'",
             "\n"
@@ -263,6 +294,34 @@
         ],
         "Instances": [{ "Ref" : "FxaEc2Instance" }],
         "SecurityGroups": [{ "Fn::GetAtt" : [ "FxaDevELBSecurityGroup", "GroupId" ] }]
+      }
+    },
+
+    "FxaRDSSecurityGroup":{
+      "Type":"AWS::RDS::DBSecurityGroup",
+      "DependsOn": "FxaDevSecurityGroup",
+      "Condition": "UseRDS",
+      "Properties":{
+        "GroupDescription":"SG to Allow access to FXA RDS",
+        "DBSecurityGroupIngress":{
+          "EC2SecurityGroupName": { "Ref":"FxaDevSecurityGroup" }
+        }
+      }
+    },
+
+    "FxaRDSInstance":{
+      "Type":"AWS::RDS::DBInstance",
+      "DependsOn": "FxaRDSSecurityGroup",
+      "Condition": "UseRDS",
+      "Properties":{
+        "AllocatedStorage": "10",
+        "BackupRetentionPeriod": 30,
+        "DBInstanceClass": "db.t2.micro",
+        "DBSecurityGroups": [ { "Ref":"FxaRDSSecurityGroup" } ],
+        "Engine": "MySQL",
+        "EngineVersion": "5.6",
+        "MasterUserPassword": { "Ref" : "RDSPassword" },
+        "MasterUsername": "root"
       }
     },
 
@@ -484,6 +543,16 @@
     "Instance" : {
       "Value" : { "Fn::GetAtt" : [ "FxaEc2Instance", "PublicDnsName" ] },
       "Description" : "DNS Name of the newly created EC2 instance"
+    },
+    "RDSEndpoint": {
+      "Description": "RDS Endpoint",
+      "Value" : {
+        "Fn::If" : [
+          "UseRDS",
+          { "Fn::GetAtt": [ "FxaRDSInstance", "Endpoint.Address" ]},
+          ""
+        ]
+      }
     },
     "BasketAccountChangeQueueURL": {
       "Description": "Fxa Account Changes for the Basket API consumer",

--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -10,6 +10,10 @@
     key_name: "{{ stack_name }}-fxadev"
     config_name: "{{ stack_name }}"
   tasks:
+    - name: generate (optional) RDS password
+      shell: openssl rand -hex 16
+      register: rds_password
+
     - name: create key pair
       local_action:
         module: ec2_key
@@ -31,6 +35,8 @@
           BranchName: "{{ fxadev_git_version }}"
           HostedZone: "{{ hosted_zone }}"
           Subdomain: "{{ subdomain }}"
+          RDSPassword: "{{ rds_password.stdout }}"
+          UseRDS: "{{ use_rds | default('false') }}"
           SSLCertificateArn: "{{ ssl_certificate_arn }}"
           EC2InstanceType: "{{ ec2_instance_type }}"
           EC2VolumeSize: "{{ ec2_volume_size | to_json }}"

--- a/aws/environments/fxadevtest.yml
+++ b/aws/environments/fxadevtest.yml
@@ -4,15 +4,11 @@ subdomain: fxadevtest.dev
 hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
 
-
 ec2_instance_type: t2.medium
 ec2_volume_size: 24
+use_rds: "true"
 
 owner: jrgm@mozilla.com
 reaper_spare_me: "true"
-
-fxadev_git_version: docker
-
-
 
 

--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -14,7 +14,6 @@ content_git_version: master
 auth_git_version: master
 authdb_git_version: master
 customs_git_version: master
-auth_mailer_git_version: master
 oauth_git_version: master
 profile_git_version: master
 rp_git_version: oauth

--- a/aws/environments/stable2.yml
+++ b/aws/environments/stable2.yml
@@ -14,7 +14,6 @@ content_git_version: master
 auth_git_version: master
 authdb_git_version: master
 customs_git_version: master
-auth_mailer_git_version: master
 oauth_git_version: master
 profile_git_version: master
 rp_git_version: oauth

--- a/aws/local.yml
+++ b/aws/local.yml
@@ -6,17 +6,6 @@
   vars_files:
     - "defaults.yml"
     - "environments/{{ stack_name }}.yml"
-  vars:
-    authdb_primary_host: "127.0.0.1"
-    authdb_primary_password: ""
-    authdb_replica_host: "127.0.0.1"
-    authdb_replica_password: ""
-    oauth_db_host: "127.0.0.1"
-    oauth_db_password: ""
-    profile_db_host: "127.0.0.1"
-    profile_db_password: ""
-    sync_db_host: "127.0.0.1"
-    sync_db_password: ""
   roles:
     - common
     - mysql

--- a/aws/roles/cron_update/tasks/main.yml
+++ b/aws/roles/cron_update/tasks/main.yml
@@ -24,6 +24,10 @@
   file: path=/var/log/ansible state=directory owner=ec2-user group=ec2-user
   become: true
 
+- name: ensure /data/fxa-dev/rds-remote.yml exists for backwards compatibility
+  become: true
+  file: state=touch path=/data/fxa-dev/rds-remote.yml
+
 # TODO the job should be a shell script that can try to recover from errors
 - name: cron update
   cron: name="fxa update"
@@ -32,4 +36,4 @@
         day={{ cron_time.day | default('*') }}
         hour={{ cron_time.hour | default('*') }}
         minute={{ cron_time.minute | default('*/2') }}
-        job="cd /data/fxa-dev/aws; PYTHONUNBUFFERED=1 /usr/bin/lckdo -x /var/tmp/ansible-update.lck /usr/bin/ansible-playbook -i localhost, local.yml --extra-vars \"stack_name={{ stack_name }} auth_sns_arn={{ auth_sns_arn }} basket_queue_url={{ basket_queue_url }} oauth_queue_url={{ oauth_queue_url }} profile_queue_url={{ profile_queue_url }} profile_update_queue_url={{ profile_update_queue_url | default('') }} customs_ban_queue_url={{ customs_ban_queue_url }}\" > /var/log/ansible/update.log"
+        job="cd /data/fxa-dev/aws; PYTHONUNBUFFERED=1 /usr/bin/lckdo -x /var/tmp/ansible-update.lck /usr/bin/ansible-playbook -i localhost, local.yml -e @/data/fxa-dev/rds-remote.yml --extra-vars \"stack_name={{ stack_name }} auth_sns_arn={{ auth_sns_arn }} basket_queue_url={{ basket_queue_url }} oauth_queue_url={{ oauth_queue_url }} profile_queue_url={{ profile_queue_url }} profile_update_queue_url={{ profile_update_queue_url | default('') }} customs_ban_queue_url={{ customs_ban_queue_url }}\" > /var/log/ansible/update.log"

--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -7,7 +7,6 @@ oauth_domain_name: "oauth-{{ domain_name }}"
 oauth_public_url: "{{ public_protocol }}://{{ oauth_domain_name }}"
 authdb_server_url: "{{ private_protocol }}://127.0.0.1:8000"
 customs_server_url: "{{ private_protocol }}://127.0.0.1:7000"
-auth_mailer_url: "{{ private_protocol }}://127.0.0.1:10136"
 auth_redirect_domain: "{{ domain_name }}"
 auth_sns_arn: ""
 auth_private_port: 9000
@@ -20,6 +19,3 @@ auth_mail_port: 25
 auth_mail_sender: "Firefox Accounts <verification@{{ domain_name }}>"
 trusted_jku_123done: "{{ public_protocol }}://123done-{{ domain_name }}/.well-known/public-keys"
 trusted_jku_321done: "{{ public_protocol }}://321done-{{ domain_name }}/.well-known/public-keys"
-auth_mailer_port: 10136
-auth_mailer_verify_url: "{{ content_public_url }}/v1/verify_email"
-auth_mailer_recovery_url: "{{ content_public_url }}/v1/complete_reset_password"

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -14,11 +14,6 @@
   file: path=/data/config/auth state=directory owner=app group=app mode=0777
   become: true
 
-#XXX obsolete?
-- name: create shared mount point for auth-mailer configuration info
-  file: path=/data/config/mailer state=directory owner=app group=app mode=0777
-  become: true
-
 - name: pull auth-server docker image
   become: true
   docker_image:
@@ -92,34 +87,6 @@
       LASTACCESSTIME_UPDATES_SAMPLE_RATE: 1
     volumes:
       - /data/config/auth:/config
-  register: container
-
-- debug: var=container
-
-- name: Start auth-mailer docker container
-  become: true
-  docker_container:
-    name: auth-mailer
-    image: mozilla/fxa-auth-server{{ ':' + auth_docker_tag }}
-    state: "{{ auth_docker_state }}"
-    network_mode: host
-    ports:
-      - "{{ auth_mailer_port }}:{{ auth_mailer_port }}"
-    command: node bin/mailer_server.js
-    env:
-      NODE_ENV: "stage"
-      MAILER_PORT: "{{ auth_mailer_port }}"
-      CONTENT_SERVER_URL: "{{ content_public_url }}"
-      IP_ADDRESS: "{{ auth_mail_host }}"
-      PORT: "{{ auth_mail_port }}"
-      # This MUST be quoted. Otherwise, it becomes pythonic `False`,
-      # which node-convict coerces to `true`.
-      MAIL_HTTPS_SECURE: "false"
-      SMTP_SENDER: "{{ auth_mail_sender }}"
-      VERIFICATION_REMINDER_TIME_FIRST: 20000
-      VERIFICATION_REMINDER_TIME_SECOND: 40000
-    volumes:
-      - /data/config/mailer:/config
   register: container
 
 - debug: var=container

--- a/roles/authdb/tasks/main.yml
+++ b/roles/authdb/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: run db_patcher
   become: true
-  command: docker run --rm --net=host -e NODE_ENV=stage mozilla/fxa-auth-db-mysql{{ ':' + authdb_docker_tag }} node bin/db_patcher.js
+  command: docker run --rm --net=host -e MYSQL_PASSWORD="{{ authdb_primary_password }}" -e MYSQL_HOST="{{ authdb_primary_host }}" -e NODE_ENV=stage mozilla/fxa-auth-db-mysql{{ ':' + authdb_docker_tag }} node bin/db_patcher.js
 
 - name: Start auth-db docker container
   become: true


### PR DESCRIPTION
This allows building an fxa-dev with an Rds database if the aws/environments/?.yml config contains `use_rds: true`. I'll use this to build a new `stable` box and port the existing database over from the existing `stable` preserving oauth clients, user accounts, etc.

This change also removes the role for `auth-mailer`, which I accidentally squashed in to the RDS changes.

I've tested that an existing fxa-dev box is not affected by these changes when it picks them up. (Note: there is no practical way to convert an existing fxa-dev box to switch to using an RDS database).