### PR TITLE
fix(cron): ensure the file has a dummy key-value pair

### DIFF
--- a/aws/roles/cron_update/tasks/main.yml
+++ b/aws/roles/cron_update/tasks/main.yml
@@ -28,6 +28,17 @@
   become: true
   file: state=touch path=/data/fxa-dev/rds-remote.yml
 
+- name: stat /data/fxa-dev/rds-remote.yml
+  become: true
+  stat: path=/data/fxa-dev/rds-remote.yml
+  register: rds_remote_file
+
+- name: insert a dummy key-value pair if file size is zero
+  become: true
+  when: rds_remote_file.stat.size == 0
+  # {{':'}} is a workaround for 'mapping values are not allowed in this context' parse error.
+  copy: content="this_space{{':'}} for_rent\n" dest=/data/fxa-dev/rds-remote.yml
+
 # TODO the job should be a shell script that can try to recover from errors
 - name: cron update
   cron: name="fxa update"


### PR DESCRIPTION
This is how it should have been; if not using rds and on an fxa-dev built before that feature was added to the docker branch, then file should exist and contain a dummy key-value (since cloud-init will not run in this case). This won't fix boxes that were running the docker branch, but will help for boxes like fxaci that run a branch off of they docker branch if/when the pick up changes from the docker branch.