### PR TITLE
feat(content-server): Enable gzip for html and static resources on the content server

### DIFF
--- a/roles/content/templates/nginx.conf.j2
+++ b/roles/content/templates/nginx.conf.j2
@@ -5,12 +5,13 @@ location / {
     proxy_pass http://upstream_content_server;
     gzip on;
     gzip_disable "msie6";
+    gzip_min_length 1100;
     gzip_vary on;
     gzip_proxied any;
-    gzip_comp_level 6;
-    gzip_buffers 16 8k;
+    gzip_comp_level 1;
+    gzip_buffers 32 4k;
     gzip_http_version 1.1;
-    gzip_types application/javascript application/x-javascript application/html image/svg+xml text/css text/javascript text/plain text/partial;
+    gzip_types application/javascript application/json application/x-javascript application/xml application/xml+rss text/css text/javascript text/plain text/xml;
 }
 
 # Note: /.well-known/ default route is defined in

--- a/roles/content/templates/nginx.conf.j2
+++ b/roles/content/templates/nginx.conf.j2
@@ -3,6 +3,14 @@ location / {
     proxy_set_header Host $http_host;
     proxy_redirect off;
     proxy_pass http://upstream_content_server;
+    gzip on;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types application/javascript application/x-javascript application/html image/svg+xml text/css text/javascript text/plain text/partial;
 }
 
 # Note: /.well-known/ default route is defined in


### PR DESCRIPTION
This should better approximate prod and ship ~ 1/2 the bytes down the wire.

@vladikoff, @jrgm or @jbuck - r?