### PR TITLE
fix(sync): start command is now just `server`

### DIFF
--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -44,7 +44,7 @@
     ports:
       - 5000:5000
 
-    command: /usr/local/bin/gunicorn --bind localhost:5000 syncserver.wsgi_app
+    command: server
 
 - debug: var=container
 - meta: flush_handlers


### PR DESCRIPTION
In https://github.com/mozilla-services/syncserver/pull/129/files#diff-60713fb19f6c50a2473835df63ff17f9R5 the docker ENTRYPOINT is now a dispatch script. So the startup command should now be server.

(However, http://127.0.0.1:5000/__version__ to the running server says `{"status": "error", "errors": ["The public_url setting doesn't match the application url.\nThis will almost certainly cause authentication failures!\n    public_url setting is: https://latest.dev.lcip.org/syncserver\n    application url is:    http://127.0.0.1:5000/syncserver\nYou can disable this check by setting the force_wsgi_environ\noption in your config file, but do so at your own risk."]}`, which may or may not be a new  problem.

r? - @vladikoff 