### PR TITLE
fix(config): remove obsolete rolename_git_version settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ your environments/foo.yml configuration file.
 
 ### Custom fxa-dev branch
 
-You can control the branch for each environment by changing the `{fxadev_git_version}` value in the environment configuration file.
-
+You can control the branch of fxa-dev for each environment by changing the `{fxadev_git_version}` value in the environment configuration file.
 
 ## Layout Notes
 

--- a/aws/environments/dcoates.yml
+++ b/aws/environments/dcoates.yml
@@ -5,10 +5,8 @@ hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
 
 auth_git_repo: https://github.com/dannycoates/picl-idp.git
-auth_git_version: ab-test
 rp_git_repo: https://github.com/dannycoates/123done.git
 content_git_repo: https://github.com/dannycoates/fxa-content-server.git
-content_git_version: ablify
 cron_time:
   minute: 0
   hour: 0

--- a/aws/environments/jrgm.yml
+++ b/aws/environments/jrgm.yml
@@ -6,11 +6,11 @@ ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02
 
 ec2_instance_type: t2.medium
 ec2_volume_size: 24
-fxadev_git_version: docker-emailservice-ses-policy
-customs_docker_state: stopped
-auth_ip_profiling_recency: '72 hours'
-auth_docker_tag: feature.emailservice
-email_service_docker_tag: feature.dockerimage
+fxadev_git_version: docker-remove-obsolete-git-version
+email_service_docker_tag: v1.118.0
+
+# intentional leftover
+oauth_git_version: v1.117.0
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"

--- a/aws/environments/stable.yml
+++ b/aws/environments/stable.yml
@@ -10,14 +10,7 @@ cron_time:
   month: 1
   day: 1
 
-content_git_version: master
-auth_git_version: master
-authdb_git_version: master
-customs_git_version: master
-oauth_git_version: master
-profile_git_version: master
 rp_git_version: oauth
-oauth_console_git_version: v0.5.1
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"

--- a/aws/environments/stable2.yml
+++ b/aws/environments/stable2.yml
@@ -10,14 +10,7 @@ cron_time:
   month: 1
   day: 1
 
-content_git_version: master
-auth_git_version: master
-authdb_git_version: master
-customs_git_version: master
-oauth_git_version: master
-profile_git_version: master
 rp_git_version: oauth
-oauth_console_git_version: v0.5.1
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"

--- a/aws/environments/stable3.yml
+++ b/aws/environments/stable3.yml
@@ -11,14 +11,7 @@ cron_time:
   hour: 22
   weekday: 4
 
-content_git_version: master
-auth_git_version: master
-authdb_git_version: master
-customs_git_version: master
-oauth_git_version: master
-profile_git_version: master
 rp_git_version: oauth
-oauth_console_git_version: v0.5.1
 
 owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"

--- a/aws/environments/stomlinson.yml
+++ b/aws/environments/stomlinson.yml
@@ -14,7 +14,6 @@ hosted_zone: lcip.org
 # ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
 ssl_certificate_arn: arn:aws:acm:us-east-1:927034868273:certificate/675e0ac8-23af-4153-8295-acb28ccc9f0f
 
-content_git_version: master
 fxadev_git_version: docker
 
 ec2_instance_type: t2.medium

--- a/aws/environments/uxwip.yml
+++ b/aws/environments/uxwip.yml
@@ -5,4 +5,3 @@ hosted_zone: lcip.org
 ssl_certificate_arn: arn:aws:acm:us-west-2:927034868273:certificate/ef6bb380-b02e-4433-9355-aec09dedd381
 
 
-content_git_version: issue-2336-new-settings-page

--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -11,7 +11,6 @@ auth_redirect_domain: "{{ domain_name }}"
 auth_sns_arn: ""
 auth_private_port: 9000
 auth_git_repo: https://github.com/mozilla/fxa-auth-server.git
-auth_git_version: master
 auth_docker_tag: latest
 auth_docker_state: started
 auth_mail_host: 127.0.0.1

--- a/roles/authdb/defaults/main.yml
+++ b/roles/authdb/defaults/main.yml
@@ -3,7 +3,6 @@ public_protocol: https
 domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 authdb_private_port: 8000
 authdb_git_repo: https://github.com/mozilla/fxa-auth-db-mysql.git
-authdb_git_version: master
 authdb_docker_tag: latest
 authdb_docker_state: started
 authdb_primary_host: 127.0.0.1

--- a/roles/basket-proxy/defaults/main.yml
+++ b/roles/basket-proxy/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 basket_proxy_git_repo: https://github.com/mozilla/fxa-basket-proxy.git
-basket_proxy_git_version: master
 basket_proxy_docker_tag: latest
 basket_docker_state: started
 basket_private_port: 1114

--- a/roles/content/defaults/main.yml
+++ b/roles/content/defaults/main.yml
@@ -12,7 +12,6 @@ content_static_resource_url: "{{ public_protocol }}://{{ domain_name }}"
 content_public_port: 80
 content_private_port: 3030
 content_git_repo: https://github.com/mozilla/fxa-content-server.git
-content_git_version: master
 content_docker_tag: latest
 content_docker_state: started
 # N.B. the leading newline on the value below is important,

--- a/roles/customs/defaults/main.yml
+++ b/roles/customs/defaults/main.yml
@@ -2,6 +2,5 @@
 customs_private_port: 7000
 customs_memcached_addr_port: 127.0.0.1:11211
 customs_git_repo: https://github.com/mozilla/fxa-customs-server.git
-customs_git_version: master
 customs_docker_tag: latest
 customs_docker_state: started

--- a/roles/oauth-console/defaults/main.yml
+++ b/roles/oauth-console/defaults/main.yml
@@ -17,6 +17,5 @@ oauth_internal_uri:  "{{ oauth_public_url }}/v1"
 profile_public_uri: "{{ public_protocol }}://{{ domain_name }}/profile/v1"
 
 oauth_console_git_repo: https://github.com/mozilla/fxa-oauth-console.git
-oauth_console_git_version: master
 oauth_console_docker_tag: latest
 oauth_console_docker_state: started

--- a/roles/oauth/defaults/main.yml
+++ b/roles/oauth/defaults/main.yml
@@ -8,7 +8,6 @@ oauth_db_host: 127.0.0.1
 oauth_db_password:
 oauth_domain_name: "oauth-{{ domain_name }}"
 oauth_git_repo: https://github.com/mozilla/fxa-oauth-server.git
-oauth_git_version: master
 oauth_docker_tag: latest
 oauth_docker_state: started
 oauth_public_url: "{{ public_protocol }}://{{ oauth_domain_name }}"

--- a/roles/profile/defaults/main.yml
+++ b/roles/profile/defaults/main.yml
@@ -5,7 +5,6 @@ domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 profile_private_port: 9011
 profile_private_static_port: 9012
 profile_git_repo: https://github.com/mozilla/fxa-profile-server.git
-profile_git_version: master
 profile_docker_tag: latest
 profile_docker_state: started
 profile_public_url: "{{ public_protocol }}://{{ domain_name }}/profile"

--- a/roles/sync/defaults/main.yml
+++ b/roles/sync/defaults/main.yml
@@ -5,7 +5,6 @@ domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 sync_private_port: 5000
 
 sync_git_repo: https://github.com/mozilla-services/syncserver.git
-sync_git_version: master
 
 sync_docker_tag: latest
 sync_docker_state: started


### PR DESCRIPTION
r? - @vladikoff 

These are all unused, and misleading.

The only two valid uses are fxadev_git_version and rp_git_version (for 123done).