### PR TITLE
feat(scopes): Add key-bearing scope for Firefox Send.

### DIFF
--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -12,29 +12,3 @@ owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"
 
 content_static_resource_url: https://static-latest.dev.lcip.org
-
-# N.B. the leading newline on the value below is important,
-# it prevents ansible from parsing it as a python dict.
-content_scoped_keys_validation: >-
-
-  {
-    "https://identity.mozilla.com/apps/oldsync": {
-      "redirectUris": [
-        "fxaclient://android.redirect",
-        "https://lockbox.firefox.com/fxa/ios-redirect.html"
-      ]
-    },
-    "https://identity.mozilla.com/apps/lockbox": {
-      "redirectUris": [
-        "https://2aa95473a5115d5f3deb36bb6875cf76f05e4c4d.extensions.allizom.org/",
-        "https://mozilla-lockbox.github.io/fxa/ios-redirect.html",
-        "https://lockbox.firefox.com/fxa/ios-redirect.html"
-      ]
-    },
-    "https://identity.mozilla.com/apps/notes": {
-      "redirectUris": [
-        "https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org/",
-        "https://mozilla.github.io/notes/fxa/android-redirect.html"
-      ]
-    }
-  }

--- a/roles/content/defaults/main.yml
+++ b/roles/content/defaults/main.yml
@@ -19,16 +19,28 @@ content_docker_state: started
 content_scoped_keys_validation: >-
 
   {
+    "https://identity.mozilla.com/apps/oldsync": {
+      "redirectUris": [
+        "fxaclient://android.redirect",
+        "https://lockbox.firefox.com/fxa/ios-redirect.html"
+      ]
+    },
     "https://identity.mozilla.com/apps/lockbox": {
        "redirectUris": [
          "https://2aa95473a5115d5f3deb36bb6875cf76f05e4c4d.extensions.allizom.org/",
-         "https://mozilla-lockbox.github.io/fxa/ios-redirect.html"
+         "https://mozilla-lockbox.github.io/fxa/ios-redirect.html",
+         "https://lockbox.firefox.com/fxa/ios-redirect.html"
        ]
      },
      "https://identity.mozilla.com/apps/notes": {
        "redirectUris": [
          "https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org/",
          "https://mozilla.github.io/notes/fxa/android-redirect.html"
+       ]
+     },
+     "https://identity.mozilla.com/apps/send": {
+       "redirectUris": [
+         "https://send2.dev.lcip.org/api/fxa/oauth"
        ]
      }
   }

--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -98,6 +98,19 @@
       "allowedScopes": "https://identity.mozilla.com/apps/lockbox"
     },
     {
+      "id": "fced6b5e3f4c66b9",
+      "name": "Firefox Send",
+      "hashedSecret": "9bf92c1039659ba630db763a02653159e827436caf486a367f10ecfac1dd6b03",
+      "redirectUri": "https://send2.dev.lcip.org/api/fxa/oauth"
+      "imageUri": "",
+      "publicClient": true,
+      "canGrant": false,
+      "termsUri": "",
+      "privacyUri": "",
+      "trusted": true,
+      "allowedScopes": "https://identity.mozilla.com/apps/send"
+    },
+    {
       "id": "ddd334467337344a",
       "name": "FxA Test WebExtension",
       "hashedSecret": "ac287a384b269492655ccd61fcadffe4d40d4d5d648209f96ee955d45f0ca05c",
@@ -411,6 +424,10 @@
     },
     {
       "scope": "https://identity.mozilla.com/apps/lockbox",
+      "hasScopedKeys": true
+    },
+    {
+      "scope": "https://identity.mozilla.com/apps/send",
       "hasScopedKeys": true
     }
   ],


### PR DESCRIPTION
As requested in https://bugzilla.mozilla.org/show_bug.cgi?id=1483369

IIUC this should be sufficient to make the new scope appear on stable.dev.lcip.org; @vladikoff r?