### PR TITLE
chore(docker): update poolee timeout for fxaci

### DIFF
--- a/aws/environments/fxaci.yml
+++ b/aws/environments/fxaci.yml
@@ -13,3 +13,4 @@ fxadev_git_version: docker
 content_public_url: "http://127.0.0.1:3030"
 auth_redirect_domain: "127.0.0.1"
 auth_signin_confirmation_skip_for_new_accounts: true
+auth_db_poolee_timeout: 15000

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -60,6 +60,7 @@
       NODE_ENV: "stage"
       PUBLIC_URL: "{{ auth_public_url }}"
       DB_BACKEND: "httpdb"
+      DB_POOLEE_TIMEOUT: "{{ auth_db_poolee_timeout | default('5000') }}"
       HTTPDB_URL: "{{ authdb_server_url }}"
       SECRET_KEY_FILE: "/config/secret-key.json"
       PUBLIC_KEY_FILE: "/config/public-key.json"


### PR DESCRIPTION
Testing fix for https://github.com/mozilla/fxa-content-server/issues/6478. Updates fxaci to have a db timeout of 15s. This is the same as pushbox.