### PR TITLE
fix(test): Disable signin confirmation for new accounts on latest

### DIFF
--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -12,3 +12,4 @@ owner: "dev-fxacct@mozilla.org"
 reaper_spare_me: "true"
 
 content_static_resource_url: https://static-latest.dev.lcip.org
+auth_signin_confirmation_skip_for_new_accounts: true


### PR DESCRIPTION
The change on fxa-dev to enable signin confirmation for new accounts the default caused the tests against latest to bust on teamcity because the tests do not expect signin confirmation.

fixes mozilla/fxa-content-server#6493

@mozilla/fxa-devs - r?