### PR TITLE
chore(docker): update recovery code count for test servers

### DIFF
--- a/aws/environments/fxaci.yml
+++ b/aws/environments/fxaci.yml
@@ -14,3 +14,4 @@ content_public_url: "http://127.0.0.1:3030"
 auth_redirect_domain: "127.0.0.1"
 auth_signin_confirmation_skip_for_new_accounts: true
 auth_db_poolee_timeout: 15000
+auth_recovery_code_count: 3

--- a/aws/environments/latest.yml
+++ b/aws/environments/latest.yml
@@ -13,3 +13,4 @@ reaper_spare_me: "true"
 
 content_static_resource_url: https://static-latest.dev.lcip.org
 auth_signin_confirmation_skip_for_new_accounts: true
+auth_recovery_code_count: 3

--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -22,3 +22,4 @@ auth_pushbox_enabled: true
 auth_pushbox_url: http://localhost:8057/
 auth_pushbox_key: Correct_Horse_Battery_Staple_1
 auth_signin_confirmation_skip_for_new_accounts: false
+auth_recovery_code_count: 8

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -90,6 +90,7 @@
       PUSHBOX_ENABLED: "{{ auth_pushbox_enabled }}"
       PUSHBOX_URL: "{{ auth_pushbox_url }}"
       PUSHBOX_KEY: "{{ auth_pushbox_key }}"
+      RECOVERY_CODE_COUNT: "{{ auth_recovery_code_count }}"
     volumes:
       - /data/config/auth:/config
   register: container


### PR DESCRIPTION
Fixes failing teamcity test https://tc-test.dev.lcip.org/viewLog.html?buildId=41815&tab=buildResultsDiv&buildTypeId=FxaLatest_FunctionalTests.

Tests expect default recovery codes create to be 3. I am not really sure how this passed on fxaci box?