### PR TITLE
fix(content): add nginx location for content-server /.well-known/change-password

### DIFF
--- a/roles/content/templates/nginx.conf.j2
+++ b/roles/content/templates/nginx.conf.j2
@@ -39,3 +39,10 @@ location /.well-known/apple-app-site-association {
     proxy_redirect off;
     proxy_pass http://upstream_content_server;
 }
+
+location /.well-known/change-password {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://upstream_content_server;
+}


### PR DESCRIPTION
I haven't tested this, but the test for this route is currently 404 on latest.dev.lcip.org, so reckon it's right.

r? - @mozilla/fxa-devs 