### PR TITLE
chore(config): Update scoped-keys redirect URI config.

### DIFF
--- a/roles/content/defaults/main.yml
+++ b/roles/content/defaults/main.yml
@@ -22,14 +22,19 @@ content_scoped_keys_validation: >-
     "https://identity.mozilla.com/apps/oldsync": {
       "redirectUris": [
         "fxaclient://android.redirect",
-        "https://lockbox.firefox.com/fxa/ios-redirect.html"
+        "https://lockbox.firefox.com/fxa/ios-redirect.html",
+        "https://lockbox.firefox.com/fxa/android-redirect.html",
+        "https://accounts.firefox.com/oauth/success/3c49430b43dfba77",
+        "https://latest.dev.lcip.org/oauth/success/3c49430b43dfba77",
+        "https://stable.dev.lcip.org/oauth/success/3c49430b43dfba77"
       ]
     },
     "https://identity.mozilla.com/apps/lockbox": {
        "redirectUris": [
          "https://2aa95473a5115d5f3deb36bb6875cf76f05e4c4d.extensions.allizom.org/",
          "https://mozilla-lockbox.github.io/fxa/ios-redirect.html",
-         "https://lockbox.firefox.com/fxa/ios-redirect.html"
+         "https://lockbox.firefox.com/fxa/ios-redirect.html",
+         "https://lockbox.firefox.com/fxa/android-redirect.html"
        ]
      },
      "https://identity.mozilla.com/apps/notes": {


### PR DESCRIPTION
This brings the dev configs in line with what we're currently shipping to production.  I think we're probably due to re-evalaute whether this extra bit of config is providing us the right value-to-annoyance ration in practice.

Perhaps we should no longer be setting specific values here for dev, and instead just using the default ones that ship with fxa-content-server?