### PR TITLE
fix(123done): remove deleted module from list to update

### DIFF
--- a/aws/local.yml
+++ b/aws/local.yml
@@ -21,7 +21,6 @@
     - email-service
     - content
     - basket-proxy
-    - rp-build
     - rp
     - rp-untrusted
     - oauth


### PR DESCRIPTION
don't try to update this delete module.

r? - @mozilla/fxa-devs 

And ugh. My previous commit has broken autoupdate on fxa-dev boxes since the ansible job won't start and, so, cannot pick up this fix on its own. To repair, ssh to your fxa-dev instance, `sudo su -`; `cd /data/fxa-dev`; `git pull`.

I will fix `latest` and `fxaci` now.