### PR TITLE
fixes for running with ansible 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,12 @@ You can control the branch of fxa-dev for each environment by changing the `{fxa
 - profile server: https://latest.dev.lcip.org/profile
 - demo oauth site: https://123done-latest.dev.lcip.org
 - ssh access: ec2-user@meta-latest.dev.lcip.org
+
+## About using docker_container and quoting of environment values
+
+`docker_container` (>=2.8) now insists that environment values be quoted. However, when evaluating `"{{ foo }}"`, those quotes are removed. So use the `to_json` jinja2 filter to ensure that the value is quoted. Note: I use `to_json` instead of `quote` because `quote` will not quote Boolean values `true` and `false`.
+
+If not quoted, the error will look like `"Non-string value found for env option. Ambiguous env options must be wrapped in quotes to avoid them being interpreted. Key: ENV_VAR_NAME"`. If you see this error, add a `to_json` in your templates and try again.
+
+
+

--- a/aws/cloudformation/moz-single.json
+++ b/aws/cloudformation/moz-single.json
@@ -644,7 +644,7 @@
             "Name" : { "Fn::Join" : [ "", ["meta-", {"Ref" : "Subdomain"}, ".", {"Ref" : "HostedZone"}, "."]]},
             "Type": "A",
             "TTL": "30",
-            "ResourceRecords" : [ { "Fn::GetAtt" : [ "FxaEc2Instance", "PublicIp" ] } ]
+            "ResourceRecords" : [ { "Ref": "FxAEIP" } ]
           }
         ]
       }

--- a/aws/roles/cron_update/tasks/main.yml
+++ b/aws/roles/cron_update/tasks/main.yml
@@ -2,7 +2,10 @@
 
 - name: install cronie
   become: true
-  yum: name=cronie state=present
+  yum:
+    name: cronie
+    state: present
+    use_backend: yum
 
 - name: start crond
   become: true

--- a/aws/roles/ses/tasks/main.yml
+++ b/aws/roles/ses/tasks/main.yml
@@ -2,11 +2,17 @@
 
 - name: no sendmail
   become: true
-  yum: name=sendmail state=absent
+  yum:
+    name: sendmail
+    state: absent
+    use_backend: yum
 
 - name: install postfix
   become: true
-  yum: name=postfix state=present
+  yum:
+    name: postfix
+    state: present
+    use_backend: yum
   notify: set MTA to postfix
 
 - name: install postfix main.cf
@@ -24,7 +30,10 @@
 # fedora 20 doesn't include rsyslog by default
 - name: install rsyslog
   become: true
-  yum: name=rsyslog state=present
+  yum:
+    name: rsyslog
+    state: present
+    use_backend: yum
 
 - name: start rsyslog
   become: true

--- a/aws/roles/team/tasks/main.yml
+++ b/aws/roles/team/tasks/main.yml
@@ -2,7 +2,10 @@
 
 - name: install human tools
   become: true
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
+    use_backend: yum
   with_items:
     - emacs-nox
     - strace

--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -49,6 +49,7 @@
 - name: Start auth-server docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: auth-server
     image: mozilla/fxa-auth-server{{ ':' + auth_docker_tag }}
     state: "{{ auth_docker_state }}"
@@ -71,26 +72,26 @@
       SMS_USE_MOCK: "true"
       SMS_STATUS_GEO_ENABLED: "false"
       SMTP_HOST: "{{ auth_mail_host }}"
-      SMTP_PORT: "{{ auth_mail_port }}"
+      SMTP_PORT: "{{ auth_mail_port | to_json }}"
       # This MUST be quoted. Otherwise, it becomes pythonic False,
       # which node-convict coerces to `true`.
       SMTP_SECURE: "false"
       SMTP_SENDER: "{{ auth_mail_sender }}"
       SECONDARY_EMAIL_ENABLED: "true"
-      SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS: "{{ auth_signin_confirmation_skip_for_new_accounts }}"
+      SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS: "{{ auth_signin_confirmation_skip_for_new_accounts | to_json }}"
       REDIRECT_DOMAIN: "{{ auth_redirect_domain | default('firefox.com')}}"
       SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX: "^(sync.*@restmail\\.net)$"
       SIGNIN_UNBLOCK_FORCED_EMAILS: "^(block.*@restmail\\.net)$"
       IP_PROFILING_RECENCY: "{{ auth_ip_profiling_recency | default('0') }}"
-      PORT: "{{ auth_private_port }}"
+      PORT: "{{ auth_private_port | to_json }}"
       SNS_TOPIC_ARN:  "{{ auth_sns_arn }}"
       PROFILE_MESSAGING_REGION: "{{ region }}"
       PROFILE_UPDATES_QUEUE_URL: "{{ profile_update_queue_url | default('') }}"
-      LASTACCESSTIME_UPDATES_SAMPLE_RATE: 1
-      PUSHBOX_ENABLED: "{{ auth_pushbox_enabled }}"
+      LASTACCESSTIME_UPDATES_SAMPLE_RATE: "1"
+      PUSHBOX_ENABLED: "{{ auth_pushbox_enabled | to_json }}"
       PUSHBOX_URL: "{{ auth_pushbox_url }}"
       PUSHBOX_KEY: "{{ auth_pushbox_key }}"
-      RECOVERY_CODE_COUNT: "{{ auth_recovery_code_count }}"
+      RECOVERY_CODE_COUNT: "{{ auth_recovery_code_count | to_json }}"
     volumes:
       - /data/config/auth:/config
   register: container
@@ -100,6 +101,7 @@
 - name: Start auth-server profile updates notification container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: auth-profile-update
     image: mozilla/fxa-auth-server{{ ':' + auth_docker_tag }}
     state: started
@@ -119,17 +121,17 @@
       CONTENT_SERVER_URL: "{{ content_public_url }}"
       OAUTH_URL: "{{ oauth_public_url }}"
       SMTP_HOST: "{{ auth_mail_host }}"
-      SMTP_PORT: "{{ auth_mail_port }}"
+      SMTP_PORT: "{{ auth_mail_port | to_json }}"
       # This MUST be quoted. Otherwise, it becomes pythonic False,
       # which node-convict coerces to `true`.
       SMTP_SECURE: "false"
       SMTP_SENDER: "{{ auth_mail_sender }}"
       SECONDARY_EMAIL_ENABLED: "true"
-      SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS: "{{ auth_signin_confirmation_skip_for_new_accounts }}"
+      SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS: "{{ auth_signin_confirmation_skip_for_new_accounts | to_json }}"
       REDIRECT_DOMAIN: "{{ auth_redirect_domain | default('firefox.com')}}"
       SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX: "^sync.*@restmail\\.net$"
       SIGNIN_UNBLOCK_FORCED_EMAILS: "^block.*@restmail\\.net$"
-      PORT: "{{ auth_private_port }}"
+      PORT: "{{ auth_private_port | to_json }}"
       SNS_TOPIC_ARN:  "{{ auth_sns_arn }}"
       PROFILE_MESSAGING_REGION: "{{ region }}"
       PROFILE_UPDATES_QUEUE_URL: "{{ profile_update_queue_url | default('') }}"

--- a/roles/authdb/tasks/main.yml
+++ b/roles/authdb/tasks/main.yml
@@ -33,6 +33,7 @@
 - name: Start auth-db docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: auth-db
     image: mozilla/fxa-auth-db-mysql{{ ':' + authdb_docker_tag }} 
     state: "{{ authdb_docker_state }}"
@@ -42,26 +43,26 @@
     command: node bin/server.js
     env:
       NODE_ENV: "stage"
-      PORT: "{{ authdb_private_port }}"
+      PORT: "{{ authdb_private_port | to_json }}"
       SCHEMA_PATCH_KEY: "schema-patch-level"
       LOG_LEVEL: "info"
-      ENABLE_PRUNING: 1
+      ENABLE_PRUNING: "1"
       MYSQL_USER: "{{ authdb_primary_user }}"
       MYSQL_PASSWORD: "{{ authdb_primary_password }}"
       MYSQL_DATABASE: "fxa"
       MYSQL_HOST: "{{ authdb_primary_host }}"
-      MYSQL_PORT: 3306
-      MYSQL_CONNECTION_LIMIT: 10
+      MYSQL_PORT: "3306"
+      MYSQL_CONNECTION_LIMIT: "10"
       MYSQL_WAIT_FOR_CONNECTIONS: "true"
-      MYSQL_QUEUE_LIMIT: 100
+      MYSQL_QUEUE_LIMIT: "100"
       MYSQL_SLAVE_USER: "{{ authdb_replica_user }}"
       MYSQL_SLAVE_PASSWORD: "{{ authdb_replica_password }}"
       MYSQL_SLAVE_DATABASE: "fxa"
       MYSQL_SLAVE_HOST: "{{ authdb_replica_host }}"
-      MYSQL_SLAVE_PORT: 3306
-      MYSQL_SLAVE_CONNECTION_LIMIT: 10
+      MYSQL_SLAVE_PORT: "3306"
+      MYSQL_SLAVE_CONNECTION_LIMIT: "10"
       MYSQL_SLAVE_WAIT_FOR_CONNECTIONS: "true"
-      MYSQL_SLAVE_QUEUE_LIMIT: 100
+      MYSQL_SLAVE_QUEUE_LIMIT: "100"
   register: container
 
 - debug: var=container

--- a/roles/basket-proxy/tasks/main.yml
+++ b/roles/basket-proxy/tasks/main.yml
@@ -39,6 +39,7 @@
 - name: Start basket-proxy server docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: basket-proxy
     image: mozilla/fxa-basket-proxy{{ ':' + basket_proxy_docker_tag }}
     state: "{{ basket_docker_state }}"
@@ -54,6 +55,7 @@
 - name: Start basket-event-handler docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: basket-event-handler
     image: mozilla/fxa-basket-proxy{{ ':' + basket_proxy_docker_tag }}
     state: "{{ basket_docker_state }}"
@@ -67,6 +69,7 @@
 - name: Start basket-fake docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: basket-fake
     image: mozilla/fxa-basket-proxy{{ ':' + basket_proxy_docker_tag }}
     state: "{{ basket_docker_state }}"

--- a/roles/channelserver/tasks/main.yml
+++ b/roles/channelserver/tasks/main.yml
@@ -23,6 +23,7 @@
 - name: Start channelserver container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: channelserver
     image: mozilla/channelserver{{ ':' + channelserver_docker_tag }}
     state: "{{ channelserver_docker_state }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -6,11 +6,17 @@
 
 - name: update installed packages
   become: true
-  yum: name=* state=latest
+  yum:
+    name: '*'
+    state: latest
+    use_backend: yum
 
 - name: install base packages
   become: true
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
+    use_backend: yum
   with_items:
     - docker
     - gcc-c++

--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -28,6 +28,7 @@
 - name: Start content-server docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: content
     image: mozilla/fxa-content-server{{ ':' + content_docker_tag }}
     state: "{{ content_docker_state }}"

--- a/roles/customs/tasks/main.yml
+++ b/roles/customs/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Start customs-server docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: customs
     image: mozilla/fxa-customs-server{{ ':' + customs_docker_tag }}
     state: "{{ customs_docker_state }}"

--- a/roles/email-service/tasks/main.yml
+++ b/roles/email-service/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Start email_service docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: email_service
     image: mozilla/fxa-email-service{{ ':' + email_service_docker_tag }}
     state: "{{ email_service_docker_state }}"

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -2,7 +2,10 @@
 
 - name: install memcached
   become: true
-  yum: name=memcached state=present
+  yum:
+    name: memcached
+    state: present
+    use_backend: yum
 
 - name: start memcached
   become: true

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -19,13 +19,14 @@
 - name: Start mysql container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: mysql
     image: mysql{{ ':' + mysql_docker_tag }}
     state: "{{ mysql_docker_state }}"
     ports:
       - 3306:3306
     env:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_ALLOW_EMPTY_PASSWORD: "1"
     volumes:
       - /var/data/mysql:/var/lib/mysql
   register: container

--- a/roles/oauth-console/tasks/main.yml
+++ b/roles/oauth-console/tasks/main.yml
@@ -33,6 +33,7 @@
 - name: start oauth-console docker container
   become: true
   docker_container:
+      # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
       name: oauth-console
       image: mozilla/fxa-oauth-console{{ ':' + oauth_console_docker_tag }}
       state: "{{ oauth_console_docker_state }}"

--- a/roles/oauth/tasks/main.yml
+++ b/roles/oauth/tasks/main.yml
@@ -31,6 +31,7 @@
 - name: Start oauth docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: oauth
     image: mozilla/fxa-oauth-server{{ ':' + oauth_docker_tag }}
     state: "{{ oauth_docker_state }}"

--- a/roles/profile/tasks/main.yml
+++ b/roles/profile/tasks/main.yml
@@ -46,6 +46,7 @@
 - name: Start profile server docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: profile
     image: mozilla/fxa-profile-server{{ ':' + profile_docker_tag }} 
     state: "{{ profile_docker_state }}"
@@ -64,6 +65,7 @@
 - name: Start profile worker docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: profile-worker
     image: mozilla/fxa-profile-server{{ ':' + profile_docker_tag }}
     state: "{{ profile_docker_state }}"
@@ -82,6 +84,7 @@
 - name: Start profile static docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: profile-static
     image: mozilla/fxa-profile-server{{ ':' + profile_docker_tag }}
     state: "{{ profile_docker_state }}"

--- a/roles/pushbox/tasks/main.yml
+++ b/roles/pushbox/tasks/main.yml
@@ -29,6 +29,7 @@
 - name: Start pushbox container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: pushbox
     image: mozilla/pushbox{{ ':' + pushbox_docker_tag }}
     state: "{{ pushbox_docker_state }}"
@@ -42,7 +43,7 @@
       ROCKET_SERVER_TOKEN: "Correct_Horse_Battery_Staple_1"
       ROCKET_FXA_HOST: "{{ oauth_public_url }}"
       ROCKET_SQS_URL: "{{ pushbox_queue_url }}"
-      ROCKET_DRYRUN: false
+      ROCKET_DRYRUN: "false"
       AWS_DEFAULT_REGION: "{{ region }}"
       RUST_BACKTRACE: "1"
   register: container

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Start redis server docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: redis
     image: redis{{ ':' + redis_docker_tag }}
     state: "{{ redis_docker_state }}"

--- a/roles/rp-untrusted/tasks/main.yml
+++ b/roles/rp-untrusted/tasks/main.yml
@@ -36,12 +36,14 @@
 - name: Ensure removal of existing `rp-untrusted` container.
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: rp-untrusted
     state: absent
 
 - name: Start 123done docker container as rp2-untrusted
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: rp2-untrusted
     image: mozilla/123done{{ ':' + rp_untrusted_docker_tag }}
     state: "{{ rp_untrusted_docker_state }}"

--- a/roles/rp/tasks/main.yml
+++ b/roles/rp/tasks/main.yml
@@ -37,12 +37,14 @@
 - name: Ensure removal of existing `rp` container.
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: rp
     state: absent
 
 - name: Start 123done docker container as trusted rp2
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: rp2
     image: mozilla/123done{{ ':' + rp_docker_tag }}
     state: "{{ rp_docker_state }}"

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -31,16 +31,17 @@
 - name: Start sync docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: syncserver
     image: mozilla/syncserver{{ ':' + sync_docker_tag }}
     state: "{{sync_docker_state}}"
     network_mode: host
     env:
-      SYNCSERVER_PUBLIC_URL: "{{ sync_public_url }}"
+      SYNCSERVER_PUBLIC_URL: "{{ sync_public_url | to_json }}"
       SYNCSERVER_IDENTITY_PROVIDER: "{{ content_public_url }}"
       SYNCSERVER_SECRET: "{{ sync_server_secret }}"
       SYNCSERVER_SQLURI: "{{ sync_sqluri }}"
-      SYNCSERVER_BATCH_UPLOAD_ENABLED: true
+      SYNCSERVER_BATCH_UPLOAD_ENABLED: "true"
     ports:
       - 5000:5000
 

--- a/roles/verifier/tasks/main.yml
+++ b/roles/verifier/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Start verifier docker container
   become: true
   docker_container:
+    # See note in https://github.com/mozilla/fxa-dev/tree/docker#about-using-docker_container-and-quoting-of-environment-values
     name: verifier
     image: mozilla/browserid-verifier{{ ':' + verifier_docker_tag }}
     state: "{{ verifier_docker_state }}"
@@ -27,11 +28,11 @@
     # `start`, as in `npm start`.
     command: start
     env:
-      COMPUTECLUSTER_MAX_PROCESSES: 1
-      COMPUTECLUSTER_MAX_BACKLOG: 500
-      IP_ADDRESS: 127.0.0.1
-      PORT: 8005
-      NODE_ENV: production
+      COMPUTECLUSTER_MAX_PROCESSES: "1"
+      COMPUTECLUSTER_MAX_BACKLOG: "500"
+      IP_ADDRESS: "127.0.0.1"
+      PORT: "8005"
+      NODE_ENV: "production"
   register: container
 
 - debug: var=container

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -2,7 +2,10 @@
 
 - name: install nginx
   become: true
-  yum: name=nginx state=present
+  yum:
+    name: nginx
+    state: present
+    use_backend: yum
 
 - name: ensure /etc/nginx/conf.d/upstream directory
   file: path=/etc/nginx/conf.d/upstream state=directory


### PR DESCRIPTION
1. fixes #455 - where we use yum, tell it to `use_backend: yum` and not dnf
2. `docker_container` is now strict about quoting environment arguments (sometimes)
3. now that we have an elastic IP, point the `meta-` address to that EIP

r? - @jbuck, @shane-tomlinson 

