### PR TITLE
fix(customs): set MAX_BAD_LOGINS{,f_PER_IP}: 1000

### DIFF
--- a/roles/customs/tasks/main.yml
+++ b/roles/customs/tasks/main.yml
@@ -32,6 +32,8 @@
       IP_ADDRESS: "0.0.0.0"
       MAX_ACCOUNT_ACCESS: "1000"
       MAX_ACCOUNT_STATUS_CHECK: "1000"
+      MAX_BAD_LOGINS: "1000"
+      MAX_BAD_LOGINS_PER_IP: "1000"
       UID_RATE_LIMIT: "1000"
       BANS_REGION: "us-west-2"
       BANS_QUEUE_URL: "{{ customs_ban_queue_url }}"


### PR DESCRIPTION
prompted by https://bugzilla.mozilla.org/show_bug.cgi?id=1555417, increase these from default levels.

r? - @vladikoff, @jbuck