### PR TITLE
fix(oauth): set publicClient=1 for "Firefox Accounts Dev" clientId

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -209,7 +209,8 @@
       "imageUri": "{{ oauth_public_url }}/img/logo@2x.png",
       "redirectUri": "",
       "trusted": true,
-      "canGrant": true
+      "canGrant": true,
+      "publicClient": true
     },
     {
       "id": "3c49430b43dfba77",


### PR DESCRIPTION
r? - @shane-tomlinson 

On `latest`, the built-in autoupdate of oauth-server was not picking up this changes for reasons that weren't clear. This was even when I did `docker stop oauth; docker rm oauth` to force a clean restart. 

So, on `latest`, I updated the database by hand to set publicClient = 1. 

This fix is for future instances; other existing may need to do the same (or someone debugs why the auto-update is not happening on restart).