### PR TITLE
Remove the "test secure proxy" client, it's not used.

### DIFF
--- a/aws/environments/oauth-sync.yml
+++ b/aws/environments/oauth-sync.yml
@@ -16,7 +16,7 @@ content_scoped_keys_validation: >-
   {
     "https://identity.mozilla.com/apps/secure-proxy": {
       "redirectUris": [
-        "https://secure-proxy.extensions.mozilla.com"
+        "https://cb7cbf5bedba243279adcd23bc6b88de7a304388.extensions.allizom.org/"
       ]
     },
     "https://identity.mozilla.com/apps/lockbox": {

--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -166,19 +166,6 @@
       "allowedScopes": "https://identity.mozilla.com/apps/oldsync"
     },
     {
-      "id": "1c7882c43994658e",
-      "name": "Test secure proxy",
-      "hashedSecret": "99716ed2927c96cdc0fb7efe57d5f124fb4161066c1ff7f4263069822256ec66",
-      "redirectUri": "https://cb7cbf5bedba243279adcd23bc6b88de7a304388.extensions.allizom.org/",
-      "imageUri": "",
-      "publicClient": true,
-      "canGrant": false,
-      "termsUri": "",
-      "privacyUri": "",
-      "trusted": true,
-      "allowedScopes": "https://identity.mozilla.com/apps/secure-proxy"
-    },
-    {
       "name": "FxA OAuth Console DEV",
       "redirectUri": "{{ oauth_public_url }}/console/oauth/redirect",
       "imageUri": "{{ oauth_public_url }}/console/oauth/image.png",


### PR DESCRIPTION
The Firefox Private Network client id is `a8c528140153d1c6` everywhere,
`1c7882c43994658e` is no longer needed. I created `a8c528140153d1c6`
not knowing `1c7882c43994658e` already existed, and then propagated the
new client id all the way to prod. Might as well just drop the old one
to reduce confusion.

@mozilla/fxa-devs - r?