### PR TITLE
fix(subscriptions): The subscriptions scope does not require scoped keys.

### DIFF
--- a/roles/oauth/templates/config.json.j2
+++ b/roles/oauth/templates/config.json.j2
@@ -344,7 +344,7 @@
     },
     {
       "scope": "https://identity.mozilla.com/account/subscriptions",
-      "hasScopedKeys": true
+      "hasScopedKeys": false
     }
   ],
   "env": "stage",


### PR DESCRIPTION
The `https://identity.mozilla.com/account/subscriptions` scope does not
require scoped keys, change `hasScopedKeys` to false. Having it set
to `true` causes an `invalid token` error to be displayed to the
user when trying to redirect from settings to payments.

issue mozilla/fxa#1835

