### PR TITLE
fix(git): do git rev-parse on chosen branch to ensure it exists

### DIFF
--- a/aws/dev.yml
+++ b/aws/dev.yml
@@ -10,6 +10,9 @@
     key_name: "{{ stack_name }}-fxadev"
     config_name: "{{ stack_name }}"
   tasks:
+    - name: check that chosen remote branch exists (did you push?). Aborts if not.
+      command: git rev-parse origin/"{{ fxadev_git_version }}"
+      
     - name: generate (optional) RDS password
       shell: openssl rand -hex 16
       register: rds_password


### PR DESCRIPTION
I've done this: branched locally, changed my config to use the new branch, and forget to push and wonder why things didn't work.

So, do a simple check that the chosen branch exists on `origin` as  a pre-flight check (and fail the run if it doesn't exist).

r? - @vbudhram 