### PR TITLE
fix(guardian): add product/client capabilities for guardian

### DIFF
--- a/roles/auth/defaults/main.yml
+++ b/roles/auth/defaults/main.yml
@@ -23,9 +23,15 @@ auth_pushbox_url: http://localhost:8057/
 auth_pushbox_key: Correct_Horse_Battery_Staple_1
 auth_signin_confirmation_skip_for_new_accounts: false
 auth_recovery_code_count: 8
+subscriptions_client_capabilities:
+  6089c54fdc970aed:
+    - guardian_vpn
+  64ef9b544a31bca8:
+    - guardian_vpn
+  dcdb5ae7add825d2:
+    - 123donePro
 subscriptions_product_capabilities:
   prod_Ex9Z1q5yVydhyk:
     - 123donePro
-subscriptions_client_capabilities: 
-  dcdb5ae7add825d2:
-    - 123donePro
+  prod_FiIHtYW7rZmzlb:
+    - guardian_vpn


### PR DESCRIPTION
r? - @bbangert 

per https://bugzilla.mozilla.org/show_bug.cgi?id=1577593

I'll note that while 6089C54FDC970AED and 64EF9B544A31BCA8 are the client_id set on the `stable` fxa-dev instance, on `latest` there are entries for this that were created and have different id, and will not work as expected. 

I suppose if there is no expectation for this product to work when authenticated by the `latests.dev.lcip.org` origin, those oauth `id` could be deleted there. 