### PR TITLE
Fix oauth quoting error

### DIFF
--- a/roles/oauth/defaults/main.yml
+++ b/roles/oauth/defaults/main.yml
@@ -4,7 +4,7 @@ private_protocol: http
 domain_name: "{{ subdomain }}.{{ hosted_zone }}"
 oauth_private_port: 9010
 oauth_db_host: 127.0.0.1
-oauth_db_password:
+oauth_db_password: ""
 oauth_domain_name: "oauth-{{ domain_name }}"
 oauth_git_repo: https://github.com/mozilla/fxa-oauth-server.git
 oauth_docker_tag: latest

--- a/roles/profile/defaults/main.yml
+++ b/roles/profile/defaults/main.yml
@@ -9,6 +9,6 @@ profile_docker_tag: latest
 profile_docker_state: started
 profile_public_url: "{{ public_protocol }}://{{ domain_name }}/profile"
 profile_db_host: 127.0.0.1
-profile_db_password:
+profile_db_password: ""
 oauth_domain_name: "oauth-{{ domain_name }}"
 oauth_public_url: "{{ public_protocol }}://{{ oauth_domain_name }}"


### PR DESCRIPTION
TASK [auth : Start auth-server profile updates notification container] *********
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Non-string value found for env option. Ambiguous env options must be wrapped in quotes to\
 avoid them being interpreted. Key: MYSQL_PASSWORD"}