### PR TITLE
feat(metrics): Add Firefox Monitor dev site to allowed metrics origins

### DIFF
--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -53,7 +53,7 @@
       SCOPED_KEYS_ENABLED: 'true'
       ANSIBLE_RESTART_FOUR: 'true'
       SCOPED_KEYS_VALIDATION: "{{ content_scoped_keys_validation }}"
-      ALLOWED_METRICS_FLOW_ORIGINS: "null,http://127.0.0.1:8001,http://localhost:8000,http://127.0.0.1:8000,https://www.mozilla.org,https://www.allizom.org,https://www-demo5.allizom.org,https://www-demo4.allizom.org,https://www-demo3.allizom.org,https://www-dev.allizom.org"
+      ALLOWED_METRICS_FLOW_ORIGINS: "null,http://127.0.0.1:8001,http://localhost:8000,http://127.0.0.1:8000,https://www.mozilla.org,https://www.allizom.org,https://www-demo5.allizom.org,https://www-demo4.allizom.org,https://www-demo3.allizom.org,https://www-dev.allizom.org,https://fx-breach-alerts.herokuapp.com"
   register: container
 
 - debug: var=container


### PR DESCRIPTION
This is important for integration testing a new FxA metrics feature: https://github.com/mozilla/fxa/issues/2743