### PR TITLE
fix(verifier): use correct command to start

### DIFF
--- a/roles/verifier/tasks/main.yml
+++ b/roles/verifier/tasks/main.yml
@@ -25,8 +25,7 @@
     network_mode: host
     ports:
       - 8005:8005
-    # `start`, as in `npm start`.
-    command: start
+    command: node server.js
     env:
       COMPUTECLUSTER_MAX_PROCESSES: "1"
       COMPUTECLUSTER_MAX_BACKLOG: "500"


### PR DESCRIPTION
This was still doing `npm start` from pre-mono-docker days.

r? - @6a68 