### PR TITLE
Revert "Fix gen_keys script with openssl (#509)"

### DIFF
--- a/roles/auth/tasks/main.yml
+++ b/roles/auth/tasks/main.yml
@@ -37,10 +37,10 @@
 - name: generate public key pair
   become: true
   command: >-
-    docker run -u 0 --rm --net=host -v /data/config/auth:/config
+    docker run --rm --net=host -v /data/config/auth:/config
       -e SECRET_KEY_FILE=/config/secret-key.json
       -e PUBLIC_KEY_FILE=/config/public-key.json
-    mozilla/fxa-auth-server sh -c 'apt-get update && apt-get install -y openssl && node scripts/gen_keys.js'
+    mozilla/fxa-auth-server node scripts/gen_keys.js
     creates=/data/config/auth/secret-key.json
 
 - name: generate vapid keys


### PR DESCRIPTION
This reverts commit 1d90c3d45c82fef31744907fb7b51146ba1cf776.

the docker image contains openssl again as of https://github.com/mozilla/fxa/pull/5772